### PR TITLE
Use read_buf for reading

### DIFF
--- a/lib/grammers-mtproto/src/transport/abridged.rs
+++ b/lib/grammers-mtproto/src/transport/abridged.rs
@@ -65,7 +65,7 @@ impl Transport for Abridged {
 
     fn unpack(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<(), Error> {
         if input.len() < 1 {
-            return Err(Error::MissingBytes(1));
+            return Err(Error::MissingBytes);
         }
 
         let header_len;
@@ -75,7 +75,7 @@ impl Transport for Abridged {
             len as u32
         } else {
             if input.len() < 4 {
-                return Err(Error::MissingBytes(4));
+                return Err(Error::MissingBytes);
             }
 
             header_len = 4;
@@ -86,7 +86,7 @@ impl Transport for Abridged {
 
         let len = len as usize * 4;
         if input.len() < header_len + len {
-            return Err(Error::MissingBytes(header_len + len));
+            return Err(Error::MissingBytes);
         }
 
         output.extend_from_slice(&input[header_len..header_len + len]);
@@ -141,7 +141,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(Error::MissingBytes(5))
+            Err(Error::MissingBytes)
         );
     }
 

--- a/lib/grammers-mtproto/src/transport/abridged.rs
+++ b/lib/grammers-mtproto/src/transport/abridged.rs
@@ -141,7 +141,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(TransportError::MissingBytes(5))
+            Err(Error::MissingBytes(5))
         );
     }
 

--- a/lib/grammers-mtproto/src/transport/full.rs
+++ b/lib/grammers-mtproto/src/transport/full.rs
@@ -189,7 +189,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(TransportError::MissingBytes(4))
+            Err(Error::MissingBytes(4))
         );
     }
 
@@ -222,7 +222,7 @@ mod tests {
         input[last] ^= 0xff;
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(TransportError::BadCrc {
+            Err(Error::BadCrc {
                 expected: 932541318,
                 got: 3365237638,
             })
@@ -238,7 +238,7 @@ mod tests {
         transport.pack(&input, &mut packed);
         assert_eq!(
             transport.unpack(&packed, &mut unpacked),
-            Err(TransportError::BadSeq {
+            Err(Error::BadSeq {
                 expected: 0,
                 got: 1,
             })

--- a/lib/grammers-mtproto/src/transport/full.rs
+++ b/lib/grammers-mtproto/src/transport/full.rs
@@ -69,7 +69,7 @@ impl Transport for Full {
     fn unpack(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<(), Error> {
         // Need 4 bytes for the initial length
         if input.len() < 4 {
-            return Err(Error::MissingBytes(4));
+            return Err(Error::MissingBytes);
         }
 
         // payload len
@@ -81,7 +81,7 @@ impl Transport for Full {
         }
 
         if input.len() < len {
-            return Err(Error::MissingBytes(len));
+            return Err(Error::MissingBytes);
         }
 
         // receive counter
@@ -189,7 +189,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(Error::MissingBytes(4))
+            Err(Error::MissingBytes)
         );
     }
 

--- a/lib/grammers-mtproto/src/transport/intermediate.rs
+++ b/lib/grammers-mtproto/src/transport/intermediate.rs
@@ -49,7 +49,7 @@ impl Transport for Intermediate {
 
     fn unpack(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<(), Error> {
         if input.len() < 4 {
-            return Err(Error::MissingBytes(4));
+            return Err(Error::MissingBytes);
         }
 
         let len = {
@@ -60,7 +60,7 @@ impl Transport for Intermediate {
             + 4;
 
         if input.len() < len {
-            return Err(Error::MissingBytes(len));
+            return Err(Error::MissingBytes);
         }
 
         output.extend_from_slice(&input[4..len]);
@@ -107,7 +107,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(Error::MissingBytes(4))
+            Err(Error::MissingBytes)
         );
     }
 

--- a/lib/grammers-mtproto/src/transport/intermediate.rs
+++ b/lib/grammers-mtproto/src/transport/intermediate.rs
@@ -107,7 +107,7 @@ mod tests {
         let mut output = Vec::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
-            Err(TransportError::MissingBytes(4))
+            Err(Error::MissingBytes(4))
         );
     }
 

--- a/lib/grammers-mtproto/src/transport/mod.rs
+++ b/lib/grammers-mtproto/src/transport/mod.rs
@@ -27,8 +27,8 @@ use std::fmt;
 /// Unless the variant is `MissingBytes`, the connection should not continue.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
-    /// Not enough bytes are provided, and the amount indicated is required to advance.
-    MissingBytes(usize),
+    /// Not enough bytes are provided.
+    MissingBytes,
 
     /// The length is either too short or too long to represent a valid packet.
     BadLen { got: u32 },
@@ -46,7 +46,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "transport error: ")?;
         match self {
-            Error::MissingBytes(n) => write!(f, "need {} bytes", n),
+            Error::MissingBytes => write!(f, "need more bytes"),
             Error::BadLen { got } => write!(f, "bad len (got {})", got),
             Error::BadSeq { expected, got } => {
                 write!(f, "bad seq (expected {}, got {})", expected, got)

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -253,7 +253,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                 self.read_buffer.clear();
                 self.process_mtp_buffer().map_err(|e| e.into())
             }
-            Err(transport::Error::MissingBytes(n)) => {
+            Err(transport::Error::MissingBytes) => {
                 Ok(Vec::new())
             }
             Err(err) => return Err(err.into()),


### PR DESCRIPTION
This uses `read_buf` for reading from the network, removing the need for transport to calculate the missing bytes.