### PR TITLE
Use BytesMut for buffers instead of Vec

### DIFF
--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -67,8 +67,9 @@ impl ClientHandle {
             media: None,
             reply_markup: new_message.reply_markup,
             entities: Some(new_message.entities),
-            schedule_date: new_message.schedule_date
-        }).await?;
+            schedule_date: new_message.schedule_date,
+        })
+        .await?;
 
         Ok(())
     }
@@ -76,7 +77,7 @@ impl ClientHandle {
     async fn a_reply_msg(
         &mut self,
         chat: &tl::enums::InputPeer,
-        id: tl::enums::InputMessage
+        id: tl::enums::InputMessage,
     ) -> (Option<tl::enums::messages::Messages>, bool) {
         if let tl::enums::InputPeer::Channel(chan) = chat {
             (
@@ -84,17 +85,19 @@ impl ClientHandle {
                     id: vec![id],
                     channel: tl::enums::InputChannel::Channel(tl::types::InputChannel {
                         channel_id: chan.channel_id,
-                        access_hash: chan.access_hash
-                    })
-                }).await.ok(),
-                false
+                        access_hash: chan.access_hash,
+                    }),
+                })
+                .await
+                .ok(),
+                false,
             )
         } else {
             (
-                self.invoke(&tl::functions::messages::GetMessages{
-                    id: vec![id]
-                }).await.ok(),
-                true
+                self.invoke(&tl::functions::messages::GetMessages { id: vec![id] })
+                    .await
+                    .ok(),
+                true,
             )
         }
     }
@@ -105,13 +108,16 @@ impl ClientHandle {
     pub async fn get_reply_to_message(
         &mut self,
         chat: tl::enums::InputPeer,
-        message: &tl::types::Message
+        message: &tl::types::Message,
     ) -> Option<tl::types::Message> {
-        let input_id = tl::enums::InputMessage::ReplyTo(tl::types::InputMessageReplyTo { id: message.id });
+        let input_id =
+            tl::enums::InputMessage::ReplyTo(tl::types::InputMessageReplyTo { id: message.id });
 
         let (mut res, mut filter_req) = self.a_reply_msg(&chat, input_id).await;
-        if res.is_none() { 
-            let input_id = tl::enums::InputMessage::Id(tl::types::InputMessageId { id: message.reply_to_message_id()? });
+        if res.is_none() {
+            let input_id = tl::enums::InputMessage::Id(tl::types::InputMessageId {
+                id: message.reply_to_message_id()?,
+            });
             let r = self.a_reply_msg(&chat, input_id).await;
             res = r.0;
             filter_req = r.1;
@@ -121,7 +127,7 @@ impl ClientHandle {
             tl::enums::messages::Messages::Messages(m) => Some(m.messages),
             tl::enums::messages::Messages::Slice(m) => Some(m.messages),
             tl::enums::messages::Messages::ChannelMessages(m) => Some(m.messages),
-            _ => None
+            _ => None,
         }?;
 
         if filter_req {

--- a/lib/grammers-client/src/ext/messages.rs
+++ b/lib/grammers-client/src/ext/messages.rs
@@ -27,7 +27,7 @@ impl MessageExt for tl::types::Message {
             Some(m.reply_to_msg_id)
         } else {
             None
-        }
+        };
     }
 
     fn from_id(&self) -> Option<i32> {
@@ -35,6 +35,6 @@ impl MessageExt for tl::types::Message {
             Some(usr.user_id)
         } else {
             None
-        }
+        };
     }
 }

--- a/lib/grammers-client/src/lib.rs
+++ b/lib/grammers-client/src/lib.rs
@@ -27,5 +27,5 @@ mod client;
 pub mod ext;
 pub mod types;
 
-pub use client::{Client, ClientHandle, Config, InitParams, UpdateIter, SignInError};
+pub use client::{Client, ClientHandle, Config, InitParams, SignInError, UpdateIter};
 pub use types::EntitySet;

--- a/lib/grammers-mtproto/Cargo.toml
+++ b/lib/grammers-mtproto/Cargo.toml
@@ -20,6 +20,7 @@ grammers-crypto = { path = "../grammers-crypto", version = "0.2.0" }
 flate2 = "1.0.13"
 num-bigint = "0.2.6"
 sha1 = "0.6.0"
+bytes = "0.6"
 
 [dependencies.grammers-tl-types]
 path = "../grammers-tl-types"

--- a/lib/grammers-mtproto/src/transport/full.rs
+++ b/lib/grammers-mtproto/src/transport/full.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use super::{Error, Transport};
-use crc::crc32::{self, Hasher32};
 use bytes::{Buf, BufMut, BytesMut};
+use crc::crc32::{self, Hasher32};
 
 /// The basic MTProto transport protocol. This is an implementation of the
 /// [full transport].
@@ -98,7 +98,7 @@ impl Transport for Full {
 
         let valid_crc = {
             let mut digest = crc32::Digest::new(crc32::IEEE);
-            digest.write(&input[..len-4]);
+            digest.write(&input[..len - 4]);
             digest.sum32()
         };
         if crc != valid_crc {
@@ -109,7 +109,7 @@ impl Transport for Full {
         }
 
         self.recv_seq += 1;
-        output.extend_from_slice(&input[8..len-4]);
+        output.extend_from_slice(&input[8..len - 4]);
         Ok(len)
     }
 }
@@ -129,7 +129,12 @@ mod tests {
         let (mut transport, expected_output, mut input) = setup_pack(n);
         transport.pack(&expected_output, &mut input);
 
-        (expected_output, Full::new(), input.to_vec(), BytesMut::new())
+        (
+            expected_output,
+            Full::new(),
+            input.to_vec(),
+            BytesMut::new(),
+        )
     }
 
     #[test]

--- a/lib/grammers-mtproto/src/transport/full.rs
+++ b/lib/grammers-mtproto/src/transport/full.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 use super::{Error, Transport};
 use crc::crc32::{self, Hasher32};
+use bytes::{Buf, BufMut, BytesMut};
 
 /// The basic MTProto transport protocol. This is an implementation of the
 /// [full transport].
@@ -40,54 +41,51 @@ impl Full {
 }
 
 impl Transport for Full {
-    fn pack(&mut self, input: &[u8], output: &mut Vec<u8>) {
+    fn pack(&mut self, input: &[u8], output: &mut BytesMut) {
         assert_eq!(input.len() % 4, 0);
 
         // payload len + length itself (4 bytes) + send counter (4 bytes) + crc32 (4 bytes)
         let len = input.len() + 4 + 4 + 4;
         output.reserve(len);
 
-        let len_bytes = (len as u32).to_le_bytes();
-        let seq = self.send_seq.to_le_bytes();
-
+        let buf_start = output.len();
+        output.put_u32_le(len as _);
+        output.put_u32_le(self.send_seq);
+        output.put(input);
         let crc = {
             let mut digest = crc32::Digest::new(crc32::IEEE);
-            digest.write(&len_bytes);
-            digest.write(&seq);
-            digest.write(input);
-            digest.sum32().to_le_bytes()
+            digest.write(&output[buf_start..]);
+            digest.sum32()
         };
-
-        output.extend_from_slice(&len_bytes);
-        output.extend_from_slice(&seq);
-        output.extend_from_slice(input);
-        output.extend_from_slice(&crc);
+        output.put_u32_le(crc);
 
         self.send_seq += 1;
     }
 
-    fn unpack(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<usize, Error> {
+    fn unpack(&mut self, input: &[u8], output: &mut BytesMut) -> Result<usize, Error> {
+        eprintln!("unpack()");
         // Need 4 bytes for the initial length
         if input.len() < 4 {
+            eprintln!("missing bytes - <4");
             return Err(Error::MissingBytes);
         }
 
+        let total_len = input.len();
+        let mut needle = &mut &input[..];
+
         // payload len
-        let mut len_bytes = [0; 4];
-        len_bytes.copy_from_slice(&input[0..4]);
-        let len = u32::from_le_bytes(len_bytes) as usize;
+        let len = needle.get_u32_le() as usize;
         if len < 12 {
             return Err(Error::BadLen { got: len as u32 });
         }
 
-        if input.len() < len {
+        if total_len < len {
+            eprintln!("missing bytes - {} < {}", total_len, len);
             return Err(Error::MissingBytes);
         }
 
         // receive counter
-        let mut seq_bytes = [0; 4];
-        seq_bytes.copy_from_slice(&input[4..8]);
-        let seq = u32::from_le_bytes(seq_bytes);
+        let seq = needle.get_u32_le();
         if seq != self.recv_seq {
             return Err(Error::BadSeq {
                 expected: self.recv_seq,
@@ -95,21 +93,15 @@ impl Transport for Full {
             });
         }
 
-        // payload
-        let body = &input[8..len - 4];
+        // skip payload for now
+        needle.advance(len - 12);
 
         // crc32
-        let crc = {
-            let mut buf = [0; 4];
-            buf.copy_from_slice(&input[len - 4..len]);
-            u32::from_le_bytes(buf)
-        };
+        let crc = needle.get_u32_le();
 
         let valid_crc = {
             let mut digest = crc32::Digest::new(crc32::IEEE);
-            digest.write(&len_bytes);
-            digest.write(&seq_bytes);
-            digest.write(body);
+            digest.write(&input[..len-4]);
             digest.sum32()
         };
         if crc != valid_crc {
@@ -120,7 +112,7 @@ impl Transport for Full {
         }
 
         self.recv_seq += 1;
-        output.extend_from_slice(body);
+        output.extend_from_slice(&input[8..len-4]);
         Ok(len)
     }
 }
@@ -130,17 +122,17 @@ mod tests {
     use super::*;
 
     /// Returns a new full transport, `n` bytes of input data for it, and an empty output buffer.
-    fn setup_pack(n: u32) -> (Full, Vec<u8>, Vec<u8>) {
+    fn setup_pack(n: u32) -> (Full, Vec<u8>, BytesMut) {
         let input = (0..n).map(|x| (x & 0xff) as u8).collect();
-        (Full::new(), input, Vec::new())
+        (Full::new(), input, BytesMut::new())
     }
 
     /// Returns the expected data after unpacking, a new full transport, input data and an empty output buffer.
-    fn setup_unpack(n: u32) -> (Vec<u8>, Full, Vec<u8>, Vec<u8>) {
+    fn setup_unpack(n: u32) -> (Vec<u8>, Full, Vec<u8>, BytesMut) {
         let (mut transport, expected_output, mut input) = setup_pack(n);
         transport.pack(&expected_output, &mut input);
 
-        (expected_output, Full::new(), input, Vec::new())
+        (expected_output, Full::new(), input.to_vec(), BytesMut::new())
     }
 
     #[test]
@@ -148,7 +140,7 @@ mod tests {
         let (mut transport, input, mut output) = setup_pack(0);
         transport.pack(&input, &mut output);
 
-        assert_eq!(&output, &[12, 0, 0, 0, 0, 0, 0, 0, 38, 202, 141, 50]);
+        assert_eq!(&output[..], &[12, 0, 0, 0, 0, 0, 0, 0, 38, 202, 141, 50]);
     }
 
     #[test]
@@ -186,7 +178,7 @@ mod tests {
     fn unpack_small() {
         let mut transport = Full::new();
         let input = [0, 1, 2];
-        let mut output = Vec::new();
+        let mut output = BytesMut::new();
         assert_eq!(
             transport.unpack(&input, &mut output),
             Err(Error::MissingBytes)
@@ -203,7 +195,7 @@ mod tests {
     #[test]
     fn unpack_twice() {
         let (mut transport, input, mut packed) = setup_pack(128);
-        let mut unpacked = Vec::new();
+        let mut unpacked = BytesMut::new();
         transport.pack(&input, &mut packed);
         transport.unpack(&packed, &mut unpacked).unwrap();
         assert_eq!(input, unpacked);
@@ -232,7 +224,7 @@ mod tests {
     #[test]
     fn unpack_bad_seq() {
         let (mut transport, input, mut packed) = setup_pack(128);
-        let mut unpacked = Vec::new();
+        let mut unpacked = BytesMut::new();
         transport.pack(&input, &mut packed);
         packed.clear();
         transport.pack(&input, &mut packed);

--- a/lib/grammers-mtproto/src/transport/full.rs
+++ b/lib/grammers-mtproto/src/transport/full.rs
@@ -63,10 +63,8 @@ impl Transport for Full {
     }
 
     fn unpack(&mut self, input: &[u8], output: &mut BytesMut) -> Result<usize, Error> {
-        eprintln!("unpack()");
         // Need 4 bytes for the initial length
         if input.len() < 4 {
-            eprintln!("missing bytes - <4");
             return Err(Error::MissingBytes);
         }
 
@@ -80,7 +78,6 @@ impl Transport for Full {
         }
 
         if total_len < len {
-            eprintln!("missing bytes - {} < {}", total_len, len);
             return Err(Error::MissingBytes);
         }
 

--- a/lib/grammers-mtproto/src/transport/mod.rs
+++ b/lib/grammers-mtproto/src/transport/mod.rs
@@ -20,6 +20,8 @@ pub use full::Full;
 pub use intermediate::Intermediate;
 use std::fmt;
 
+use bytes::BytesMut;
+
 /// The error type reported by the different transports when something is wrong.
 ///
 /// Certain transports will only produce certain variants of this error.
@@ -65,12 +67,12 @@ pub trait Transport {
     /// Previous contents in `output` are not cleared before this operation.
     ///
     /// Panics if `input.len()` is not divisible by 4.
-    fn pack(&mut self, input: &[u8], output: &mut Vec<u8>);
+    fn pack(&mut self, input: &[u8], output: &mut BytesMut);
 
     /// Unpacks the content from `input` into `output`.
     ///
     /// Previous contents in `output` are not cleared before this operation.
     ///
     /// If successful, returns how many bytes of `input` were used.
-    fn unpack(&mut self, input: &[u8], output: &mut Vec<u8>) -> Result<usize, Error>;
+    fn unpack(&mut self, input: &[u8], output: &mut BytesMut) -> Result<usize, Error>;
 }

--- a/lib/grammers-mtsender/Cargo.toml
+++ b/lib/grammers-mtsender/Cargo.toml
@@ -19,6 +19,7 @@ grammers-crypto = { path = "../grammers-crypto", version = "0.2.0" }
 grammers-mtproto = { path = "../grammers-mtproto", version = "0.2.0" }
 grammers-tl-types = { path = "../grammers-tl-types", version = "0.2.0", features = [ "tl-mtproto" ]}
 tokio = { version = "0.3", features = ["net", "io-util", "sync"] }
+bytes = "0.6"
 log = "0.4"
 futures = { version = "0.3", default-features = false }
 

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 mod errors;
 
+use bytes::{Buf, BytesMut};
 pub use errors::{AuthorizationError, InvocationError, ReadError};
 use futures::future::FutureExt as _;
 use futures::{future, pin_mut};
@@ -21,7 +22,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
-use bytes::{Buf,BytesMut};
 
 /// The maximum data that we're willing to send or receive at once.
 ///

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -214,7 +214,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
         // TODO make mtp itself use BytesMut to avoid copies
         let mut temp_vec = vec![];
         let msg_ids = self.mtp.serialize(&requests, &mut temp_vec);
-        self.mtp_buffer.extend_from_slice(&temp_vec);
+        self.mtp_buffer = temp_vec[..].into();
         self.write_buffer.clear();
         self.transport
             .pack(&self.mtp_buffer, &mut self.write_buffer);

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
+use bytes::{Buf,BytesMut};
 
 /// The maximum data that we're willing to send or receive at once.
 ///
@@ -38,13 +39,13 @@ pub struct Sender<T: Transport, M: Mtp> {
     stream: TcpStream,
     transport: T,
     mtp: M,
-    mtp_buffer: Vec<u8>,
+    mtp_buffer: BytesMut,
 
     requests: Vec<Request>,
 
     // Transport-level buffers and positions
-    read_buffer: Vec<u8>,
-    write_buffer: Vec<u8>,
+    read_buffer: BytesMut,
+    write_buffer: BytesMut,
     write_index: usize,
 }
 
@@ -69,12 +70,12 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
             stream,
             transport,
             mtp,
-            mtp_buffer: Vec::with_capacity(MAXIMUM_DATA),
+            mtp_buffer: BytesMut::with_capacity(MAXIMUM_DATA),
 
             requests: vec![],
 
-            read_buffer: Vec::with_capacity(MAXIMUM_DATA),
-            write_buffer: Vec::with_capacity(MAXIMUM_DATA),
+            read_buffer: BytesMut::with_capacity(MAXIMUM_DATA),
+            write_buffer: BytesMut::with_capacity(MAXIMUM_DATA),
             write_index: 0,
         })
     }
@@ -210,7 +211,10 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
             return;
         }
 
-        let msg_ids = self.mtp.serialize(&requests, &mut self.mtp_buffer);
+        // TODO make mtp itself use BytesMut to avoid copies
+        let mut temp_vec = vec![];
+        let msg_ids = self.mtp.serialize(&requests, &mut temp_vec);
+        self.mtp_buffer.extend_from_slice(&temp_vec);
         self.write_buffer.clear();
         self.transport
             .pack(&self.mtp_buffer, &mut self.write_buffer);
@@ -252,7 +256,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                 .unpack(&self.read_buffer, &mut self.mtp_buffer)
             {
                 Ok(n) => {
-                    self.read_buffer.drain(..n);
+                    self.read_buffer.advance(n);
                     self.process_mtp_buffer(&mut updates)?;
                 }
                 Err(transport::Error::MissingBytes) => break,

--- a/lib/grammers-mtsender/tests/lib.rs
+++ b/lib/grammers-mtsender/tests/lib.rs
@@ -20,7 +20,7 @@ use tokio::runtime;
 
 #[test]
 fn test_invoke_encrypted_method() {
-    simple_logger::init_with_level(log::Level::Debug).unwrap();
+    simple_logger::init_with_level(log::Level::Trace).unwrap();
 
     let rt = runtime::Builder::new_current_thread()
         .enable_all()

--- a/lib/grammers-mtsender/tests/lib.rs
+++ b/lib/grammers-mtsender/tests/lib.rs
@@ -20,7 +20,7 @@ use tokio::runtime;
 
 #[test]
 fn test_invoke_encrypted_method() {
-    simple_logger::init_with_level(log::Level::Trace).unwrap();
+    simple_logger::init_with_level(log::Level::Debug).unwrap();
 
     let rt = runtime::Builder::new_current_thread()
         .enable_all()


### PR DESCRIPTION
This allows for further architecture improvements in the future, and simplifies transport code.