### PR TITLE
declare module `parsers` in lib.rs

### DIFF
--- a/lib/grammers-client/src/lib.rs
+++ b/lib/grammers-client/src/lib.rs
@@ -40,6 +40,7 @@
 //! [extension traits]: crate::ext
 mod client;
 pub mod ext;
+mod parsers;
 pub mod types;
 pub(crate) mod utils;
 


### PR DESCRIPTION
Fixes build when using either `html` or `markdown` features of `grammers-client`