### PR TITLE
Do not download the same file chunk all the time

### DIFF
--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -93,6 +93,7 @@ impl DownloadIter {
                     }
                 }
 
+                self.request.offset += self.request.limit;
                 Ok(Some(f.bytes))
             }
             File::CdnRedirect(_) => {


### PR DESCRIPTION
Without this fix, we download the safe file chunk on each next.