### PR TITLE
Photo may not be presented if the photo is already expired

### DIFF
--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -548,7 +548,7 @@ impl ClientHandle {
     /// let mut photos = client.iter_profile_photos(&chat);
     ///
     /// while let Some(photo) = photos.next().await? {
-    ///     println!("Did you know chat has a photo with ID {}?", photo.id());
+    ///     println!("Did you know chat has a photo with ID {}?", photo.id().unwrap());
     /// }
     /// # Ok(())
     /// # }

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -67,12 +67,15 @@ impl Photo {
         })
     }
 
-    pub fn id(&self) -> i64 {
+    /// Get photo id.
+    ///
+    /// Photo id may be missing in case of expired photo.
+    pub fn id(&self) -> Option<i64> {
         use tl::enums::Photo as P;
 
-        match self.photo.photo.as_ref().unwrap() {
-            P::Empty(photo) => photo.id,
-            P::Photo(photo) => photo.id,
+        match self.photo.photo.as_ref()? {
+            P::Empty(photo) => Some(photo.id),
+            P::Photo(photo) => Some(photo.id),
         }
     }
 


### PR DESCRIPTION
Hi! It's not safe to unwrap a photo because it may be missing in cases when this is an expired photo. 

![image](https://user-images.githubusercontent.com/4203721/112653527-92bf9b00-8e5f-11eb-968c-6745912b17f3.png)
