### PR TITLE
Further improve upload performance

### DIFF
--- a/lib/grammers-client/src/client/client.rs
+++ b/lib/grammers-client/src/client/client.rs
@@ -21,6 +21,7 @@ const DEFAULT_LOCALE: &str = "en";
 /// Configuration required to create a [`Client`] instance.
 ///
 /// [`Client`]: struct.Client.html
+#[derive(Clone)]
 pub struct Config {
     /// Session storage where data should persist, such as authorization key, server address,
     /// and other required information by the client.
@@ -42,6 +43,7 @@ pub struct Config {
 
 /// Optional initialization parameters, required when initializing a connection to Telegram's
 /// API.
+#[derive(Clone)]
 pub struct InitParams {
     pub device_model: String,
     pub system_version: String,

--- a/lib/grammers-session/src/lib.rs
+++ b/lib/grammers-session/src/lib.rs
@@ -38,6 +38,12 @@ pub struct Session {
     session: Mutex<types::Session>,
 }
 
+impl Clone for Session {
+    fn clone(&self) -> Self {
+        Self::load(&self.save()).unwrap()
+    }
+}
+
 impl Session {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
This PR continues the work done in #73 and further improves the upload performance drastically by creating multiple connections to the telegram servers. (Upload of a 23MB takes now ~1100ms (before ~2700-3000ms) on a 1Gbit/s connection)