### PR TITLE
Generate impls for tl enums

### DIFF
--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -15,9 +15,6 @@ use crate::{ignore_type, Config};
 use grammers_tl_parser::tl::{Category, Definition, ParameterType};
 use std::io::{self, Write};
 
-/// Types that implement Copy from builtin_type
-const COPY_TYPES: [&'static str; 5] = ["bool", "f64", "i32", "i64", "u32"];
-
 /// Get the list of generic parameters:
 ///
 /// ```ignore
@@ -90,66 +87,6 @@ fn write_struct<W: Write>(
                     indent,
                     rustifier::parameters::attr_name(param),
                     rustifier::parameters::qual_name(param),
-                )?;
-            }
-        }
-    }
-    writeln!(file, "{}}}", indent)?;
-    Ok(())
-}
-
-/// Defines `impl` to get values from fields from the struct
-/// See #33 for idea
-///
-/// ```ignore
-/// #[allow(dead_code)]
-/// impl Name {
-///     pub fn field(&self) -> FieldType {
-///         &self.field
-///     }
-/// }
-/// ```
-fn write_impl<W: Write>(
-    file: &mut W,
-    indent: &str,
-    def: &Definition,
-    _metadata: &Metadata,
-    _config: &Config,
-) -> io::Result<()> {
-    writeln!(
-        file,
-        // allow dead_code for grammers-session, because some tl types are private
-        "{}#[allow(dead_code)]\n{}impl{} {}{} {{",
-        indent,
-        indent,
-        get_generic_param_list(def, true),
-        rustifier::definitions::type_name(def),
-        get_generic_param_list(def, false)
-    )?;
-    for param in def.params.iter() {
-        match param.ty {
-            ParameterType::Flags => {}
-            ParameterType::Normal { .. } => {
-                let qual_name = rustifier::parameters::qual_name(param);
-                // For generics return borrowed value because they don't have to implement Clone
-                let prefix = if qual_name.len() == 1 { "&" } else { "" };
-                writeln!(
-                    file,
-                    "{}    pub fn {}(&self) -> {}{} {{\n{}        {}self.{}{}\n{}    }}",
-                    indent,
-                    rustifier::parameters::attr_name(param),
-                    prefix,
-                    qual_name,
-                    indent,
-                    prefix,
-                    rustifier::parameters::attr_name(param),
-                    // .clone() for !Copy types and generics
-                    if !COPY_TYPES.contains(&qual_name.as_str()) && prefix.is_empty() {
-                        ".clone()"
-                    } else {
-                        ""
-                    },
-                    indent
                 )?;
             }
         }
@@ -533,7 +470,6 @@ fn write_definition<W: Write>(
     config: &Config,
 ) -> io::Result<()> {
     write_struct(file, indent, def, metadata, config)?;
-    write_impl(file, indent, def, metadata, config)?;
     write_identifiable(file, indent, def, metadata)?;
     write_serializable(file, indent, def, metadata)?;
     if def.category == Category::Types || config.deserializable_functions {

--- a/lib/grammers-tl-parser/src/tl/flag.rs
+++ b/lib/grammers-tl-parser/src/tl/flag.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use crate::errors::ParamParseError;
 
 /// Data attached to parameters conditional on flags.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Flag {
     /// The name of the parameter containing the flags in its bits.
     pub name: String,

--- a/lib/grammers-tl-parser/src/tl/parameter.rs
+++ b/lib/grammers-tl-parser/src/tl/parameter.rs
@@ -12,7 +12,7 @@ use crate::errors::ParamParseError;
 use crate::tl::ParameterType;
 
 /// A single parameter, with a name and a type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Parameter {
     /// The name of the parameter.
     pub name: String,

--- a/lib/grammers-tl-parser/src/tl/parameter_type.rs
+++ b/lib/grammers-tl-parser/src/tl/parameter_type.rs
@@ -12,7 +12,7 @@ use crate::errors::ParamParseError;
 use crate::tl::{Flag, Type};
 
 /// A parameter type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum ParameterType {
     /// This parameter represents a flags field (`u32`).
     Flags,

--- a/lib/grammers-tl-parser/src/tl/ty.rs
+++ b/lib/grammers-tl-parser/src/tl/ty.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use crate::errors::ParamParseError;
 
 /// The type of a definition or a parameter.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Type {
     /// The namespace components of the type.
     pub namespace: Vec<String>,


### PR DESCRIPTION
Hello, I've implemented issue #33 - generator for `impl`s for TL structs. All `Copy` values are returned as is, cloneable cloned (Options, Strings...), and generics are returned as borrows (because they don't have to implement `Clone`). Thanks