### PR TITLE
switch back to iterators for aes

### DIFF
--- a/lib/grammers-crypto/src/aes.rs
+++ b/lib/grammers-crypto/src/aes.rs
@@ -61,7 +61,7 @@ pub fn ige_decrypt(ciphertext: &[u8], key: &[u8; 32], iv: &[u8; 32]) -> Vec<u8> 
         plaintext_block
             .iter_mut()
             .zip(ciphertext_block)
-            .zip(iv1.as_ref())
+            .zip(iv2.as_ref())
             .for_each(|((a, x), b)| *a = x ^ b);
 
         // block = decrypt(block);
@@ -71,7 +71,7 @@ pub fn ige_decrypt(ciphertext: &[u8], key: &[u8; 32], iv: &[u8; 32]) -> Vec<u8> 
         // block = block XOR iv1
         plaintext_block
             .iter_mut()
-            .zip(iv2.as_ref())
+            .zip(iv1.as_ref())
             .for_each(|(a, b)| *a ^= b);
 
         // save plaintext and adjust iv


### PR DESCRIPTION
Hello,
simd optimizations are fixed with rust 1.55.

We should probably keep using this even if a future compiler version causes a regression again for whatever reason,
as rust iterators are more likely to be simd optimized (citation needed)

Thank you and regards.