### PR TITLE
Added methods for joining and leaving a chat. Removed useless compile-time environment macros

### DIFF
--- a/lib/grammers-client/examples/dialogs.rs
+++ b/lib/grammers-client/examples/dialogs.rs
@@ -14,7 +14,6 @@ use grammers_client::{Client, Config, SignInError};
 use grammers_session::Session;
 use log;
 use simple_logger::SimpleLogger;
-use std::env;
 use std::io::{self, BufRead as _, Write as _};
 use tokio::{runtime, task};
 
@@ -42,8 +41,8 @@ async fn async_main() -> Result<()> {
         .init()
         .unwrap();
 
-    let api_id = env!("TG_ID").parse().expect("TG_ID invalid");
-    let api_hash = env!("TG_HASH").to_string();
+    let api_id = std::env::var("TG_ID")?.parse()?;
+    let api_hash = std::env::var("TG_HASH")?;
 
     println!("Connecting to Telegram...");
     let mut client = Client::connect(Config {

--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -40,9 +40,9 @@ async fn async_main() -> Result {
         .init()
         .unwrap();
 
-    let api_id = env!("TG_ID").parse().expect("TG_ID invalid");
-    let api_hash = env!("TG_HASH").to_string();
-    let token = env::args().skip(1).next().expect("token missing");
+    let api_id = std::env::var("TG_ID")?.parse()?;
+    let api_hash = std::env::var("TG_HASH")?;
+    let token = env::args().nth(1).expect("token missing");
 
     println!("Connecting to Telegram...");
     let mut client = Client::connect(Config {

--- a/lib/grammers-client/examples/inline-pagination.rs
+++ b/lib/grammers-client/examples/inline-pagination.rs
@@ -110,9 +110,9 @@ async fn async_main() -> Result {
         .init()
         .unwrap();
 
-    let api_id = env!("TG_ID").parse().expect("TG_ID invalid");
-    let api_hash = env!("TG_HASH").to_string();
-    let token = env::args().skip(1).next().expect("token missing");
+    let api_id = std::env::var("TG_ID")?.parse()?;
+    let api_hash = std::env::var("TG_HASH")?;
+    let token = env::args().nth(1).expect("token missing");
 
     println!("Connecting to Telegram...");
     let mut client = Client::connect(Config {

--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -21,7 +21,6 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
-use tl::enums;
 
 const MAX_PARTICIPANT_LIMIT: usize = 200;
 const MAX_PHOTO_LIMIT: usize = 100;

--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -80,8 +80,15 @@ impl Channel {
     }
 
     /// Return the unique identifier for this channel.
+    #[inline]
     pub fn id(&self) -> i32 {
         self.0.id
+    }
+
+    /// Return access hash for this channel
+    #[inline]
+    pub fn access_hash(&self) -> Option<i64> {
+        self.0.access_hash
     }
 
     /// Pack this channel into a smaller representation that can be loaded later.
@@ -93,7 +100,7 @@ impl Channel {
                 PackedType::Broadcast
             },
             id: self.id(),
-            access_hash: self.0.access_hash,
+            access_hash: self.access_hash(),
         }
     }
 

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -67,16 +67,20 @@ impl Group {
         }
     }
 
+    /// Return the access hash for this group.
+    pub fn access_hash(&self) -> Option<i64> {
+        use tl::enums::Chat;
+
+        match &self.0 {
+            Chat::Empty(_) | Chat::Chat(_) | Chat::Forbidden(_) => None,
+            Chat::Channel(chat) => chat.access_hash,
+            Chat::ChannelForbidden(chat) => Some(chat.access_hash),
+        }
+    }
+
     /// Pack this group into a smaller representation that can be loaded later.
     pub fn pack(&self) -> PackedChat {
-        use tl::enums::Chat;
-        let (id, access_hash) = match &self.0 {
-            Chat::Empty(chat) => (chat.id, None),
-            Chat::Chat(chat) => (chat.id, None),
-            Chat::Forbidden(chat) => (chat.id, None),
-            Chat::Channel(chat) => (chat.id, chat.access_hash),
-            Chat::ChannelForbidden(chat) => (chat.id, Some(chat.access_hash)),
-        };
+        let (id, access_hash) = (self.id(), self.access_hash());
 
         PackedChat {
             ty: if self.is_megagroup() {

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -79,6 +79,15 @@ impl Chat {
         }
     }
 
+    /// Return the access hash for this chat
+    pub fn access_hash(&self) -> Option<i64> {
+        match self {
+            Self::User(user) => user.access_hash(),
+            Self::Group(grp) => grp.access_hash(),
+            Self::Channel(chan) => chan.access_hash(),
+        }
+    }
+
     /// Return the name of this chat.
     ///
     /// For private conversations (users), this is their first name. For groups and channels,


### PR DESCRIPTION
Join and leave methods:
Similar to the already implemented `kick_participant` which leaves a chat if you attempt to kick yourself, the now implemented `leave_chat` and `join_chat` follow the same structure. 

Remove of compile-time macro:
examples don't need compile-time environments to work. In fact, I think they have been misused in this case. I also fixed a clippy error in the process.