### PR TITLE
Return errors occuring when stepping

### DIFF
--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -92,8 +92,9 @@ impl Client {
             let deadline = message_box.check_deadlines();
             drop(message_box);
             tokio::select! {
-                _ = self.step() => {
-                    log::trace!("stepped")
+                step = self.step() => {
+                    log::trace!("stepped");
+                    step?
                 }
                 _ = sleep_until(deadline.into()) => {
                     log::trace!("slept")


### PR DESCRIPTION
# Issue

If the TcpStream closes, Client::next_update enters an endless loop, using 100% CPU.

# Steps to reproduce

- While connected to internet, start a program that uses Client::next_update.
- Once the client connected to Telegram, disconnect it from internet
- Continue to call Client::next_update and wait for up to one minute
- Client::next_update continuously call Client::step, which instantly reads 0 bytes from the closed TcpStream and returns an error

# Fix

Check the return value of the Client::step and if it's an error, return it.

(This bug seems to have been introduced in 24a2895e670e9c3e50fec617f5592929fb91a73b)