### PR TITLE
Implement support to `MessageEntityMentionName`

### DIFF
--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -65,13 +65,21 @@ fn map_random_ids_to_messages(
     }
 }
 
-fn parse_mention_entities(client: &Client, mut entities: Vec<tl::enums::MessageEntity>) -> Option<Vec<tl::enums::MessageEntity>> {
+fn parse_mention_entities(
+    client: &Client,
+    mut entities: Vec<tl::enums::MessageEntity>,
+) -> Option<Vec<tl::enums::MessageEntity>> {
     if entities.is_empty() {
         None
     } else {
         for entitie in entities.iter_mut() {
             if let tl::enums::MessageEntity::MentionName(mention_name) = entitie {
-                if let Some(packed_user) = client.0.chat_hashes.lock("messages.parse_mention_entities").get(mention_name.user_id) {
+                if let Some(packed_user) = client
+                    .0
+                    .chat_hashes
+                    .lock("messages.parse_mention_entities")
+                    .get(mention_name.user_id)
+                {
                     *entitie = tl::types::InputMessageEntityMentionName {
                         offset: mention_name.offset,
                         length: mention_name.length,

--- a/lib/grammers-client/src/parsers.rs
+++ b/lib/grammers-client/src/parsers.rs
@@ -117,7 +117,7 @@ pub fn parse_markdown_message(message: &str) -> (String, Vec<tl::enums::MessageE
             update_entity_len!(Italic(offset) => entities);
         }
 
-        // [text link](https://example.com)
+        // [text link](https://example.com) or [user mention](tg://user?id=12345678)
         Event::Start(Tag::Link(_kind, url, _title)) => {
             if url.starts_with("tg://user?id") {
                 let user_id = url[13..].parse::<i64>().unwrap();
@@ -388,7 +388,7 @@ mod tests {
         let (text, entities) = parse_markdown_message(
             "Some **bold** (__strong__), *italics* (_cursive_), inline `code`, \
             a\n```rust\npre\n```\nblock, a [link](https://example.com), and \
-            [mentions](tg://user?id=10885151)",
+            [mentions](tg://user?id=12345678)",
         );
 
         assert_eq!(
@@ -438,7 +438,7 @@ mod tests {
                 tl::types::MessageEntityMentionName {
                     offset: 78,
                     length: 8,
-                    user_id: 10885151
+                    user_id: 12345678
                 }
                 .into(),
             ]
@@ -526,7 +526,7 @@ mod tests {
             "Some <b>bold</b> (<strong>strong</strong>), <i>italics</i> \
             (<em>cursive</em>), inline <code>code</code>, a <pre>pre</pre> \
             block, a <a href=\"https://example.com\">link</a>, and \
-            <a href=\"tg://user?id=10885151\">mentions</a>",
+            <a href=\"tg://user?id=12345678\">mentions</a>",
         );
 
         assert_eq!(
@@ -576,7 +576,7 @@ mod tests {
                 tl::types::MessageEntityMentionName {
                     offset: 77,
                     length: 8,
-                    user_id: 10885151
+                    user_id: 12345678
                 }
                 .into(),
             ]

--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -308,7 +308,9 @@ impl InputMessage {
     /// message contents and entities.
     ///
     /// Note that Telegram only supports a very limited subset of entities:
-    /// bold, italic, underline, strikethrough, code blocks, pre blocks and inline links.
+    /// bold, italic, underline, strikethrough, code blocks, pre blocks and inline links (inline
+    /// links with this format `tg://user?id=12345678` will be replaced with inline mentions when
+    /// possible).
     #[cfg(feature = "markdown")]
     pub fn markdown<T: AsRef<str>>(s: T) -> Self {
         let (text, entities) = crate::parsers::parse_markdown_message(s.as_ref());
@@ -323,7 +325,9 @@ impl InputMessage {
     /// message contents and entities.
     ///
     /// Note that Telegram only supports a very limited subset of entities:
-    /// bold, italic, underline, strikethrough, code blocks, pre blocks and inline links.
+    /// bold, italic, underline, strikethrough, code blocks, pre blocks and inline links (inline
+    /// links with this format `tg://user?id=12345678` will be replaced with inline mentions when
+    /// possible).
     #[cfg(feature = "html")]
     pub fn html<T: AsRef<str>>(s: T) -> Self {
         let (text, entities) = crate::parsers::parse_html_message(s.as_ref());


### PR DESCRIPTION
With this, you can mention users either using html or markdown.