### PR TITLE
added Clone to message deletion

### DIFF
--- a/lib/grammers-client/src/types/message_update.rs
+++ b/lib/grammers-client/src/types/message_update.rs
@@ -4,7 +4,7 @@
 ///
 /// When `MessageDeletion#channel_id` is Some, it means the message was deleted
 /// from a channel.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MessageDeletion {
     pub(crate) channel_id: Option<i64>,
     pub(crate) messages: Vec<i32>,


### PR DESCRIPTION
The Update enum implements Clone but MessageDeletion didn't so the crate won't compile.
This PR fixes that issue
