### PR TITLE
Port messagebox from Telethon

### DIFF
--- a/lib/grammers-session/src/lib.rs
+++ b/lib/grammers-session/src/lib.rs
@@ -15,7 +15,7 @@ pub use generated::LAYER as VERSION;
 pub use message_box::{PrematureEndReason, channel_id};
 use generated::{enums, types};
 use grammers_tl_types::deserialize::Error as DeserializeError;
-pub use message_box::MessageBox;
+pub use message_box::{MessageBox, Gap};
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::{File, OpenOptions};

--- a/lib/grammers-session/src/lib.rs
+++ b/lib/grammers-session/src/lib.rs
@@ -12,6 +12,7 @@ mod message_box;
 pub use chat::{ChatHashCache, PackedChat, PackedType};
 pub use generated::types::User;
 pub use generated::LAYER as VERSION;
+pub use message_box::{PrematureEndReason, channel_id};
 use generated::{enums, types};
 use grammers_tl_types::deserialize::Error as DeserializeError;
 pub use message_box::MessageBox;

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -421,6 +421,11 @@ impl MessageBox {
         update: tl::enums::Update,
         reset_deadline: ResetDeadline,
     ) -> Option<tl::enums::Update> {
+        if let tl::enums::Update::ChannelTooLong(u) = update {
+            self.begin_get_diff(Entry::Channel(u.channel_id));
+            return None;
+        }
+
         let pts = match PtsInfo::from_update(&update) {
             Some(pts) => pts,
             // No pts means that the update can be applied in any order.

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -536,7 +536,10 @@ impl MessageBox {
         for entry in [Entry::AccountWide, Entry::SecretChats] {
             if self.getting_diff_for.contains(&entry) {
                 if self.map.get(&entry).is_none() {
-                    panic!("Should not try to get difference for an entry {:?} without known state", entry);
+                    panic!(
+                        "Should not try to get difference for an entry {:?} without known state",
+                        entry
+                    );
                 }
 
                 return Some(tl::functions::updates::GetDifference {
@@ -742,13 +745,10 @@ impl MessageBox {
                     },
                 })
             } else {
-                // TODO investigate when/why/if this can happen
-                warn!(
-                    "cannot getChannelDifference for {} as we're missing its pts",
-                    id
+                panic!(
+                    "Should not try to get difference for an entry {:?} without known state",
+                    entry
                 );
-                self.end_get_diff(entry);
-                None
             }
         } else {
             warn!(

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -808,7 +808,7 @@ impl MessageBox {
 
                 self.map.get_mut(&entry).unwrap().pts = pts;
                 updates.extend(new_messages.into_iter().map(|message| {
-                    tl::types::UpdateNewMessage {
+                    tl::types::UpdateNewChannelMessage {
                         message,
                         pts: NO_SEQ,
                         pts_count: NO_SEQ,

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -488,7 +488,7 @@ impl MessageBox {
         } else {
             // No previous `pts` known, and because this update has to be "right" (it's the first one) our
             // `local_pts` must be one less.
-            pts.pts - 1
+            pts.pts - pts.pts_count
         };
 
         // For example, when we're in a channel, we immediately receive:

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -197,8 +197,7 @@ impl MessageBox {
             state.deadline = deadline;
             debug!("reset deadline {:?} for {:?}", deadline, entry);
         } else {
-            // TODO figure out why this happens
-            info!("did not reset deadline for {:?} as it had no entry", entry);
+            panic!("did not reset deadline for {:?} as it had no entry", entry);
         }
 
         if self.next_deadline == Some(entry) {
@@ -448,6 +447,8 @@ impl MessageBox {
         // the "no updates" period for that entry is reset.
         //
         // Build the `HashSet` to avoid calling `reset_deadline` more than once for the same entry.
+        //
+        // By the time this method returns, self.map will have an entry for which we can reset its deadline.
         if reset_deadline == ResetDeadline::Yes {
             self.reset_deadlines_for.insert(pts.entry);
         }

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -203,14 +203,12 @@ impl MessageBox {
 
         if self.next_deadline == Some(entry) {
             // If the updated deadline was the closest one, recalculate the new minimum.
-            self.next_deadline = Some(
-                *self
-                    .map
-                    .iter()
-                    .min_by_key(|(_, state)| state.deadline)
-                    .unwrap()
-                    .0,
-            );
+            // TODO figure out when reset_deadline may be called while self.map is empty
+            self.next_deadline = self
+                .map
+                .iter()
+                .min_by_key(|(_, state)| state.deadline)
+                .map(|i| *i.0);
         } else if self
             .next_deadline
             .map(|e| deadline < self.map[&e].deadline)

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -202,7 +202,6 @@ impl MessageBox {
 
         if self.next_deadline == Some(entry) {
             // If the updated deadline was the closest one, recalculate the new minimum.
-            // TODO figure out when reset_deadline may be called while self.map is empty
             self.next_deadline = Some(
                 self.map
                     .iter()

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -535,22 +535,20 @@ impl MessageBox {
     pub fn get_difference(&mut self) -> Option<tl::functions::updates::GetDifference> {
         for entry in [Entry::AccountWide, Entry::SecretChats] {
             if self.getting_diff_for.contains(&entry) {
-                if let Some(_state) = self.map.get(&entry) {
-                    return Some(tl::functions::updates::GetDifference {
-                        pts: self.map[&Entry::AccountWide].pts,
-                        pts_total_limit: None,
-                        date: self.date,
-                        qts: if self.map.contains_key(&Entry::SecretChats) {
-                            self.map[&Entry::SecretChats].pts
-                        } else {
-                            NO_SEQ
-                        },
-                    });
-                } else {
-                    // TODO investigate when/why/if this can happen
-                    warn!("cannot getDifference as we're missing account pts");
-                    self.end_get_diff(entry);
+                if self.map.get(&entry).is_none() {
+                    panic!("Should not try to get difference for an entry {:?} without known state", entry);
                 }
+
+                return Some(tl::functions::updates::GetDifference {
+                    pts: self.map[&Entry::AccountWide].pts,
+                    pts_total_limit: None,
+                    date: self.date,
+                    qts: if self.map.contains_key(&Entry::SecretChats) {
+                        self.map[&Entry::SecretChats].pts
+                    } else {
+                        NO_SEQ
+                    },
+                });
             }
         }
         None

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -581,7 +581,6 @@ impl MessageBox {
                 finish = true;
                 self.date = diff.date;
                 self.seq = diff.seq;
-                self.end_get_diff(Entry::AccountWide);
                 result = (Vec::new(), Vec::new(), Vec::new())
             }
             tl::enums::updates::Difference::Difference(diff) => {
@@ -590,7 +589,6 @@ impl MessageBox {
                     diff.state
                 );
                 finish = true;
-                self.end_get_diff(Entry::AccountWide);
                 chat_hashes.extend(&diff.users, &diff.chats);
                 result = self.apply_difference_type(diff, chat_hashes)?
             }
@@ -634,7 +632,7 @@ impl MessageBox {
             let secret = self.getting_diff_for.get(&Entry::SecretChats).is_some();
 
             if !account && !secret {
-                panic!("Should not be applying the difference when neither account or secret was diff was active")
+                panic!("Should not be applying the difference when neither account or secret diff was active")
             }
 
             if account {

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -496,20 +496,21 @@ impl MessageBox {
             pts.pts - pts.pts_count
         };
 
-        // For example, when we're in a channel, we immediately receive:
+        // In a channel, we may immediately receive:
         // * ReadChannelInbox (pts = X)
         // * NewChannelMessage (pts = X, pts_count = 1)
         //
-        // Notice how both `pts` are the same. If we stored the one from the first, then the second one would
-        // be considered "already handled" and ignored, which is not desirable. Instead, advance local `pts`
-        // by `pts_count` (which is 0 for updates not directly related to messages, like reading inbox).
+        // Notice how both `pts` are the same. The first one however would've triggered a gap
+        // because `local_pts` + `pts_count` of 0 would be less than `remote_pts`. So there is
+        // no risk by setting the `local_pts` to match the `remote_pts` here of missing the new
+        // message.
         self.map
             .entry(pts.entry)
             .or_insert_with(|| State {
-                pts: local_pts + pts.pts_count,
+                pts: pts.pts,
                 deadline: next_updates_deadline(),
             })
-            .pts = local_pts + pts.pts_count;
+            .pts = pts.pts;
 
         Some(update)
     }


### PR DESCRIPTION
Each commit that is a direct copy contains hash of commit in Telethon.

Those not having it are fixups that don't directly correspond to any Telethon commits.