### PR TITLE
fix: cannot use grammers as dependency

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -34,7 +34,7 @@ mime_guess = "2.0.3"
 os_info = { version = "3.0.4", default_features = false }
 pin-project-lite = "0.2"
 pulldown-cmark = { version = "0.8.0", default-features = false, optional = true }
-tokio = { version = "1.5.0", features = ["sync", "fs", "macros", "time", "sync"] }
+tokio = { version = "1.5.0", features = ["sync", "fs", "macros", "time", "sync", "rt"] }
 
 [dev-dependencies]
 simple_logger = { version = "1.11.0", default-features = false, features = ["colors"] }


### PR DESCRIPTION
While `cargo build --all` inside the `grammers` repository itself works without issues, trying to use `grammers-client` as dependency in an external application results in failure:

```bash
$ cargo build
---- SNIP ----
error[E0425]: cannot find function `spawn` in module `tokio::task`
   --> /home/dev/.cargo/git/checkouts/grammers-689e30b82f69dcd5/ba5341c/lib/grammers-client/src/client/files.rs:228:37
    |
228 |             let task = tokio::task::spawn(async move {
    |                                     ^^^^^ not found in `tokio::task`
    |
help: consider importing this function
    |
9   | use std::thread::spawn;
    |
help: if you import `spawn`, refer to it directly
    |
228 -             let task = tokio::task::spawn(async move {
228 +             let task = spawn(async move {
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `grammers-client` due to previous error
```

(this is from a fresh `cargo init` project except with `grammers-client` specified as dependency)

This issue is preventing `grammers` to be used at all.

After investigation, it turns out to be a `tokio` feature resolution issue. When building inside the repo, the `rt` feature of `tokio` is enabled since it's specified in the `[dev-dependencies]` section. However, when used a library outside of the repo, the `[dev-dependencies]` section is ignored and the `tokio` crate is resolved without the `rt` feature enabled, causing the build failure.

This PR fixes the issue, simply by enabling `rt` in the `[dependencies]` section as well.