### PR TITLE
Make `PasswordToken::hint` return `Option<&str>`

### DIFF
--- a/lib/grammers-client/src/types/password_token.rs
+++ b/lib/grammers-client/src/types/password_token.rs
@@ -17,7 +17,7 @@ impl PasswordToken {
         PasswordToken { password }
     }
 
-    pub fn hint(&self) -> Option<&String> {
-        self.password.hint.as_ref()
+    pub fn hint(&self) -> Option<&str> {
+        self.password.hint.as_deref()
     }
 }


### PR DESCRIPTION
Fix to https://github.com/Lonami/grammers/issues/131.