### PR TITLE
Implement `Channel::username()`

### DIFF
--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -113,7 +113,6 @@ impl Channel {
     pub fn username(&self) -> Option<&str> {
         self.0.username.as_deref()
     }
-
 }
 
 impl From<Channel> for PackedChat {

--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -103,6 +103,17 @@ impl Channel {
     pub fn title(&self) -> &str {
         self.0.title.as_str()
     }
+
+    /// Return the public @username of this channel, if any.
+    ///
+    /// The returned username does not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of Telegram's URLs, such
+    /// as https://t.me/username.
+    pub fn username(&self) -> Option<&str> {
+        self.0.username.as_deref()
+    }
+
 }
 
 impl From<Channel> for PackedChat {

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -104,6 +104,21 @@ impl Group {
         }
     }
 
+    /// Return the public @username of this group, if any.
+    ///
+    /// The returned username does not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of Telegram's URLs, such
+    /// as https://t.me/username.
+    pub fn username(&self) -> Option<&str> {
+        use tl::enums::Chat;
+
+        match &self.0 {
+            Chat::Empty(_) | Chat::Chat(_) | Chat::Forbidden(_) | Chat::ChannelForbidden(_) => None,
+            Chat::Channel(channel) => channel.username.as_deref(),
+        }
+    }
+
     /// Returns true if this group is a megagroup (also known as supergroups).
     ///
     /// In case inner type of group is Channel, that means it's a megagroup.

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -136,6 +136,20 @@ impl Chat {
             )),
         }
     }
+
+    /// Return the public @username of this chat, if any.
+    ///
+    /// The returned username does not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of Telegram's URLs, such
+    /// as https://t.me/username.
+    pub fn username(&self) -> Option<&str> {
+        match self {
+            Self::User(user) => user.username(),
+            Self::Group(group) => group.username(),
+            Self::Channel(channel) => channel.username(),
+        }
+    }
 }
 
 impl From<Chat> for PackedChat {


### PR DESCRIPTION
With this, you can use `channel.username()` to get a megagroup/channel username.