### PR TITLE
Implement FILE_MIGRATE handling

### DIFF
--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -21,7 +21,7 @@ use tokio::{
 
 pub const MIN_CHUNK_SIZE: i32 = 4 * 1024;
 pub const MAX_CHUNK_SIZE: i32 = 512 * 1024;
-pub const FILE_MIGRATE_ERROR: i32 = 303;
+const FILE_MIGRATE_ERROR: i32 = 303;
 const BIG_FILE_SIZE: usize = 10 * 1024 * 1024;
 const WORKER_COUNT: usize = 4;
 


### PR DESCRIPTION
This PR implements handling of ```FILE_MIGRATE``` errors when trying to download a file that lives in a different datacenter:

  * Maintains a ```HashMap<i32, FileDownloader>``` at client level
  * Detects the error, picks the ```Sender``` from the session datacenter, exports the auth and imports into a new ```Sender``` that will be stored in the ```HashMap```
  * Redo the request
  
  
  ~~WIP: Depends on https://github.com/Lonami/grammers/pull/146~~
