### PR TITLE
Fix 'API is returning peers without access_hash' assertion error

### DIFF
--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -117,10 +117,8 @@ impl ParticipantIter {
                 };
 
                 let mut chat_hashes = client.0.chat_hashes.lock("iter_participants");
-                assert!(
-                    chat_hashes.extend(&full.users, &full.chats),
-                    "API is returning peers without access_hash"
-                );
+                // Telegram can return peers without hash (e.g. Users with 'min: true')
+                let _ = chat_hashes.extend(&full.users, &full.chats);
                 drop(chat_hashes);
 
                 // Don't actually care for the chats, just the users.
@@ -150,10 +148,8 @@ impl ParticipantIter {
                     };
 
                 let mut chat_hashes = iter.client.0.chat_hashes.lock("iter_participants");
-                assert!(
-                    chat_hashes.extend(&users, &chats),
-                    "API is returning peers without access_hash"
-                );
+                // Telegram can return peers without hash (e.g. Users with 'min: true')
+                let _ = chat_hashes.extend(&users, &chats);
                 drop(chat_hashes);
 
                 // Telegram can return less participants than asked for but the count being higher
@@ -363,10 +359,8 @@ impl Client {
         };
 
         let mut chat_hashes = self.0.chat_hashes.lock("resolve_username");
-        assert!(
-            chat_hashes.extend(&users, &chats),
-            "API is returning peers without access_hash"
-        );
+        // Telegram can return peers without hash (e.g. Users with 'min: true')
+        let _ = chat_hashes.extend(&users, &chats);
         drop(chat_hashes);
 
         Ok(match peer {

--- a/lib/grammers-client/src/client/dialogs.rs
+++ b/lib/grammers-client/src/client/dialogs.rs
@@ -83,10 +83,8 @@ impl DialogIter {
         };
 
         let mut chat_hashes = self.client.0.chat_hashes.lock("iter_dialogs");
-        assert!(
-            chat_hashes.extend(&users, &chats),
-            "API is returning peers without access_hash"
-        );
+        // Telegram can return peers without hash (e.g. Users with 'min: true')
+        let _ = chat_hashes.extend(&users, &chats);
         drop(chat_hashes);
 
         let chats = ChatMap::new(users, chats);

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -145,10 +145,8 @@ impl<R: tl::RemoteCall<Return = tl::enums::messages::Messages>> IterBuffer<R, Me
         };
 
         let mut chat_hashes = self.client.0.chat_hashes.lock("iter_messages");
-        assert!(
-            chat_hashes.extend(&users, &chats),
-            "API is returning peers without access_hash"
-        );
+        // Telegram can return peers without hash (e.g. Users with 'min: true')
+        let _ = chat_hashes.extend(&users, &chats);
         drop(chat_hashes);
 
         let chats = ChatMap::new(users, chats);


### PR DESCRIPTION
Error happens when executing  ```cargo run --example dialogs``` or  ```cargo run --example downloader -- CHAT``` due to a users with ```min: true``` being returned