### PR TITLE
Include document with thumb in InputMessage

### DIFF
--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -175,6 +175,63 @@ impl InputMessage {
         self
     }
 
+    /// Include the video file with thumb in the message.
+    ///
+    /// The text will be the caption of the document, which may be empty for no caption.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// async fn f(client: &mut grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let thumb = client.upload_file("thumb.png").await?;
+    /// let video = client.upload_file("video.mp4").await?;
+    ///
+    /// let message = InputMessage::text("").document_thumb(video, Some(thumb)).attribute(
+    /// Attribute::Video {
+    ///     round_message: (false),
+    ///     supports_streaming: (true),
+    ///     duration: duration,
+    ///     w: width,
+    ///     h: height,
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn document_thumb(mut self, file: Uploaded, thumb: Option<Uploaded>) -> Self {
+        let mime_type = self.get_file_mime(&file);
+        let file_name = file.name().to_string();
+        if let Some(thumb) = thumb {
+            self.media = Some(
+                tl::types::InputMediaUploadedDocument {
+                    nosound_video: false,
+                    force_file: false,
+                    file: file.input_file,
+                    thumb: Some(thumb.input_file),
+                    mime_type,
+                    attributes: vec![tl::types::DocumentAttributeFilename { file_name }.into()],
+                    stickers: None,
+                    ttl_seconds: self.media_ttl,
+                }
+                .into(),
+            );
+            return self;
+        }
+        self.media = Some(
+            tl::types::InputMediaUploadedDocument {
+                nosound_video: false,
+                force_file: false,
+                file: file.input_file,
+                thumb: None,
+                mime_type,
+                attributes: vec![tl::types::DocumentAttributeFilename { file_name }.into()],
+                stickers: None,
+                ttl_seconds: self.media_ttl,
+            }
+            .into(),
+        );
+        self
+    }
+
     /// Include an external file as a document in the message.
     ///
     /// You can use this to send videos, stickers, audios, or uncompressed photos.


### PR DESCRIPTION
When I upload a video, the thumb is missing. please add the method so that we can upload video with thumb.