### PR TITLE
Fix up clippy lints

### DIFF
--- a/bin/tl-to-json/src/main.rs
+++ b/bin/tl-to-json/src/main.rs
@@ -82,7 +82,6 @@ fn main() -> std::io::Result<()> {
             methods: Vec::new(),
         };
         parse_tl_file(&tl)
-            .into_iter()
             .filter_map(Result::ok)
             .for_each(|def| match def.category {
                 tl::Category::Types => schema.constructors.push(Constructor {

--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -65,7 +65,7 @@ impl DownloadIter {
     /// the range `MIN_CHUNK_SIZE..=MAX_CHUNK_SIZE`.
     pub fn chunk_size(mut self, size: i32) -> Self {
         assert!((MIN_CHUNK_SIZE..=MAX_CHUNK_SIZE).contains(&size) && size % MIN_CHUNK_SIZE == 0);
-        self.request.limit = size as i32;
+        self.request.limit = size;
         self
     }
 

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -56,6 +56,7 @@ impl Client {
                 let mut message_box = self.0.message_box.lock("client.next_update");
                 // This temporary is needed or message_box's lifetime is extended too much.
                 // See https://github.com/rust-lang/rust/issues/102423.
+                #[allow(clippy::let_and_return)]
                 let diff = message_box.get_difference();
                 diff
             } {
@@ -72,6 +73,7 @@ impl Client {
             if let Some(request) = {
                 let mut message_box = self.0.message_box.lock("client.next_update");
                 let chat_hashes = self.0.chat_hashes.lock("client.next_update");
+                #[allow(clippy::let_and_return)]
                 let diff = message_box.get_channel_difference(&chat_hashes);
                 diff
             } {

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -157,7 +157,7 @@ impl Chat {
     // (Obtaining the non-min hash may require locking so it's desirable to check first, and also
     // to avoid double work to update it later, but it may not be possible to update it if the hash
     // is missing).
-    pub(crate) fn get_min_hash_ref<'a>(&'a mut self) -> Option<(&'a mut bool, &'a mut i64)> {
+    pub(crate) fn get_min_hash_ref(&mut self) -> Option<(&mut bool, &mut i64)> {
         match self {
             Self::User(user) => match (&mut user.0.min, user.0.access_hash.as_mut()) {
                 (m @ true, Some(ah)) => Some((m, ah)),

--- a/lib/grammers-client/src/types/chat_map.rs
+++ b/lib/grammers-client/src/types/chat_map.rs
@@ -66,7 +66,7 @@ impl ChatMap {
     }
 
     /// Retrieve the full `Chat` object given its `Peer`.
-    pub fn get<'a, 'b>(&'a self, peer: &'b tl::enums::Peer) -> Option<&'a Chat> {
+    pub fn get(&self, peer: &tl::enums::Peer) -> Option<&Chat> {
         self.map.get(&peer.into())
     }
 

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -291,6 +291,7 @@ impl Document {
         match self.document.document.as_ref() {
             Some(tl::enums::Document::Document(d)) => {
                 for attr in &d.attributes {
+                    #[allow(clippy::single_match)]
                     match attr {
                         tl::enums::DocumentAttribute::Audio(a) => return a.title.clone(),
                         _ => {}
@@ -307,6 +308,7 @@ impl Document {
         match self.document.document.as_ref() {
             Some(tl::enums::Document::Document(d)) => {
                 for attr in &d.attributes {
+                    #[allow(clippy::single_match)]
                     match attr {
                         tl::enums::DocumentAttribute::Audio(a) => return a.performer.clone(),
                         _ => {}

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -263,7 +263,7 @@ impl Document {
                         _ => {}
                     }
                 }
-                return None;
+                None
             }
             _ => None,
         }
@@ -280,7 +280,7 @@ impl Document {
                         _ => {}
                     }
                 }
-                return None;
+                None
             }
             _ => None,
         }
@@ -296,7 +296,7 @@ impl Document {
                         _ => {}
                     }
                 }
-                return None;
+                None
             }
             _ => None,
         }
@@ -312,7 +312,7 @@ impl Document {
                         _ => {}
                     }
                 }
-                return None;
+                None
             }
             _ => None,
         }

--- a/lib/grammers-crypto/src/auth_key.rs
+++ b/lib/grammers-crypto/src/auth_key.rs
@@ -67,7 +67,7 @@ impl AuthKey {
         };
 
         let mut result = [0u8; 16];
-        result.copy_from_slice(&Sha1::from(&data).digest().bytes()[4..]);
+        result.copy_from_slice(&Sha1::from(data).digest().bytes()[4..]);
         result
     }
 }

--- a/lib/grammers-crypto/src/two_factor_auth.rs
+++ b/lib/grammers-crypto/src/two_factor_auth.rs
@@ -162,7 +162,7 @@ fn ph2(password: impl AsRef<[u8]>, salt1: &[u8], salt2: &[u8]) -> Output<Sha256>
     let mut dk = [0u8; 64];
     pbkdf2::pbkdf2::<Hmac<Sha512>>(&hash1, salt1, 100000, &mut dk);
 
-    sh(&dk, salt2)
+    sh(dk, salt2)
 }
 
 fn xor(left: &Output<Sha256>, right: &Output<Sha256>) -> Vec<u8> {

--- a/lib/grammers-crypto/src/two_factor_auth.rs
+++ b/lib/grammers-crypto/src/two_factor_auth.rs
@@ -150,7 +150,7 @@ fn sh(data: impl AsRef<[u8]>, salt: impl AsRef<[u8]>) -> Output<Sha256> {
 
 // PH1(password, salt1, salt2) := SH(SH(password, salt1), salt2)
 fn ph1(password: impl AsRef<[u8]>, salt1: &[u8], salt2: &[u8]) -> Output<Sha256> {
-    sh(&sh(password, salt1), salt2)
+    sh(sh(password, salt1), salt2)
 }
 
 // PH2(password, salt1, salt2)

--- a/lib/grammers-mtproto/src/authentication.rs
+++ b/lib/grammers-mtproto/src/authentication.rs
@@ -386,7 +386,7 @@ fn do_step3(
 
             let new_nonce_hash = {
                 let mut buffer = [0; 16];
-                buffer.copy_from_slice(&Sha1::from(&new_nonce).digest().bytes()[4..20]);
+                buffer.copy_from_slice(&Sha1::from(new_nonce).digest().bytes()[4..20]);
                 buffer
             };
             check_new_nonce_hash(&server_dh_params.new_nonce_hash, &new_nonce_hash)?;

--- a/lib/grammers-session/build.rs
+++ b/lib/grammers-session/build.rs
@@ -29,7 +29,6 @@ fn main() -> std::io::Result<()> {
         session flags:# dcs:Vector<DataCenter> user:flags.0?User state:flags.1?UpdateState = Session;
         "#,
     )
-    .into_iter()
     .map(Result::unwrap)
     .collect::<Vec<_>>();
 

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -655,7 +655,7 @@ impl MessageBox {
             }
             tl::enums::updates::Difference::Difference(diff) => {
                 // TODO return Err(attempt to find users)
-                drop(chat_hashes.extend(&diff.users, &diff.chats));
+                let _ = chat_hashes.extend(&diff.users, &diff.chats);
 
                 debug!(
                     "handling full difference {:?}; no longer getting diff",
@@ -673,7 +673,7 @@ impl MessageBox {
                 intermediate_state: state,
             }) => {
                 // TODO return Err(attempt to find users)
-                drop(chat_hashes.extend(&users, &chats));
+                let _ = chat_hashes.extend(&users, &chats);
 
                 debug!("handling partial difference {:?}", state);
                 finish = false;
@@ -872,7 +872,7 @@ impl MessageBox {
             }
             tl::enums::updates::ChannelDifference::TooLong(diff) => {
                 // TODO return Err(attempt to find users)
-                drop(chat_hashes.extend(&diff.users, &diff.chats));
+                let _ = chat_hashes.extend(&diff.users, &diff.chats);
 
                 assert!(diff.r#final);
                 info!(
@@ -908,7 +908,7 @@ impl MessageBox {
                 },
             ) => {
                 // TODO return Err(attempt to find users)
-                drop(chat_hashes.extend(&users, &chats));
+                let _ = chat_hashes.extend(&users, &chats);
 
                 if r#final {
                     debug!(

--- a/lib/grammers-tl-gen/src/enums.rs
+++ b/lib/grammers-tl-gen/src/enums.rs
@@ -403,7 +403,7 @@ pub(crate) fn write_enums_mod<W: Write>(
             "    "
         };
 
-        for ty in grouped[key].iter().filter(|ty| !ignore_type(*ty)) {
+        for ty in grouped[key].iter().filter(|ty| !ignore_type(ty)) {
             write_definition(&mut file, indent, ty, metadata, config)?;
         }
 

--- a/lib/grammers-tl-gen/tests/lib.rs
+++ b/lib/grammers-tl-gen/tests/lib.rs
@@ -14,7 +14,6 @@ const LAYER: i32 = 0;
 
 fn get_definitions(contents: &str) -> Vec<Definition> {
     parse_tl_file(contents)
-        .into_iter()
         .map(|d| d.unwrap())
         .collect()
 }

--- a/lib/grammers-tl-gen/tests/lib.rs
+++ b/lib/grammers-tl-gen/tests/lib.rs
@@ -13,9 +13,7 @@ use std::io;
 const LAYER: i32 = 0;
 
 fn get_definitions(contents: &str) -> Vec<Definition> {
-    parse_tl_file(contents)
-        .map(|d| d.unwrap())
-        .collect()
+    parse_tl_file(contents).map(|d| d.unwrap()).collect()
 }
 
 fn gen_rust_code(definitions: &[Definition]) -> io::Result<String> {

--- a/lib/grammers-tl-parser/src/utils.rs
+++ b/lib/grammers-tl-parser/src/utils.rs
@@ -33,6 +33,7 @@ pub(crate) fn remove_tl_comments(contents: &str) -> String {
 
 /// Infers the identifier for a definition.
 pub(crate) fn infer_id(definition: &str) -> u32 {
+    #[allow(clippy::collapsible_str_replace)]
     let mut representation = definition
         .replace(":bytes ", ": string")
         .replace("?bytes ", "? string")

--- a/lib/grammers-tl-types/build.rs
+++ b/lib/grammers-tl-types/build.rs
@@ -21,7 +21,6 @@ fn load_tl(file: &str) -> io::Result<Vec<Definition>> {
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
     Ok(parse_tl_file(&contents)
-        .into_iter()
         .filter_map(|d| match d {
             Ok(d) => Some(d),
             Err(e) => {


### PR DESCRIPTION
Here be 17 commits that manually fix a bunch of lints highlighted by Cargo's Clippy.

None should alter the code's behavior and should amount to make the code a bit cleaner.