### PR TITLE
Account for less than 2 salts in request buffer

### DIFF
--- a/lib/grammers-mtproto/src/mtp/encrypted.rs
+++ b/lib/grammers-mtproto/src/mtp/encrypted.rs
@@ -1156,11 +1156,16 @@ impl Mtp for Encrypted {
         // Check to see if the next salt can be used already. If it can, drop the current one and,
         // if the next salt is the last one, fetch more.
         if let Some((start_secs, start_instant)) = self.start_salt_time {
-            if let Some(salt) = self.salts.get(self.salts.len() - 2) {
+            if let Some(salt) = self
+                .salts
+                .len()
+                .checked_sub(2)
+                .and_then(|x| self.salts.get(x))
+            {
                 let now = start_secs + start_instant.elapsed().as_secs() as i32;
                 if now >= salt.valid_since + SALT_USE_DELAY {
                     self.salts.pop();
-                    if self.salts.len() == 1 {
+                    if self.salts.len() <= 1 {
                         info!("only one future salt remaining; asking for more salts");
                         let body = tl::functions::GetFutureSalts {
                             num: NUM_FUTURE_SALTS,

--- a/lib/grammers-mtproto/src/mtp/encrypted.rs
+++ b/lib/grammers-mtproto/src/mtp/encrypted.rs
@@ -1156,12 +1156,7 @@ impl Mtp for Encrypted {
         // Check to see if the next salt can be used already. If it can, drop the current one and,
         // if the next salt is the last one, fetch more.
         if let Some((start_secs, start_instant)) = self.start_salt_time {
-            if let Some(salt) = self
-                .salts
-                .len()
-                .checked_sub(2)
-                .and_then(|x| self.salts.get(x))
-            {
+            if let Some(salt) = self.salts.len().checked_sub(2).map(|x| &self.salts[x]) {
                 let now = start_secs + start_instant.elapsed().as_secs() as i32;
                 if now >= salt.valid_since + SALT_USE_DELAY {
                     self.salts.pop();

--- a/lib/grammers-mtproto/src/mtp/encrypted.rs
+++ b/lib/grammers-mtproto/src/mtp/encrypted.rs
@@ -1160,7 +1160,7 @@ impl Mtp for Encrypted {
                 let now = start_secs + start_instant.elapsed().as_secs() as i32;
                 if now >= salt.valid_since + SALT_USE_DELAY {
                     self.salts.pop();
-                    if self.salts.len() <= 1 {
+                    if self.salts.len() == 1 {
                         info!("only one future salt remaining; asking for more salts");
                         let body = tl::functions::GetFutureSalts {
                             num: NUM_FUTURE_SALTS,


### PR DESCRIPTION
This change accounts for a case when there is only 0 or 1 salt in the request buffer, instead of panicking on a subtraction underflow error.

The panic happened to me regularly when Grammers is connected to a Telegram test server regularly, and I hope this should fix that from happening.