### PR TITLE
Feature "unstable_raw" to access some of the private raw fields

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -18,6 +18,7 @@ markdown = ["pulldown-cmark"]
 html = ["html5ever"]
 proxy = ["grammers-mtsender/proxy"]
 parse_invite_link = ["url"]
+unstable_raw = []
 
 [dependencies]
 chrono = "0.4.19"
@@ -26,7 +27,9 @@ grammers-crypto = { path = "../grammers-crypto", version = "0.4.0" }
 grammers-mtproto = { path = "../grammers-mtproto", version = "0.4.0" }
 grammers-mtsender = { path = "../grammers-mtsender", version = "0.4.0" }
 grammers-session = { path = "../grammers-session", version = "0.4.1" }
-grammers-tl-types = { path = "../grammers-tl-types", version = "0.4.0", features = ["tl-mtproto"] }
+grammers-tl-types = { path = "../grammers-tl-types", version = "0.4.0", features = [
+    "tl-mtproto",
+] }
 html5ever = { version = "0.25.1", optional = true }
 locate-locale = "0.2.0"
 log = "0.4.14"
@@ -35,10 +38,19 @@ mime_guess = "2.0.3"
 os_info = { version = "3.0.4", default_features = false }
 pin-project-lite = "0.2"
 pulldown-cmark = { version = "0.8.0", default-features = false, optional = true }
-tokio = { version = "1.5.0", features = ["sync", "fs", "macros", "time", "sync", "rt"] }
-url = {version = "2.2.2", optional = true}
+tokio = { version = "1.5.0", features = [
+    "sync",
+    "fs",
+    "macros",
+    "time",
+    "sync",
+    "rt",
+] }
+url = { version = "2.2.2", optional = true }
 
 [dev-dependencies]
-simple_logger = { version = "1.11.0", default-features = false, features = ["colors"] }
+simple_logger = { version = "1.11.0", default-features = false, features = [
+    "colors",
+] }
 tokio = { version = "1.5.0", features = ["rt", "signal"] }
 toml = "0.5.8"

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// join more of them. Certain actions in official clients, like setting a chat's username,
 /// silently upgrade the chat to a megagroup.
 #[derive(Clone)]
-pub struct Group(tl::enums::Chat);
+pub struct Group(pub(crate) tl::enums::Chat);
 
 impl fmt::Debug for Group {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -36,6 +36,14 @@ pub enum Chat {
     Channel(Channel),
 }
 
+#[cfg(feature = "unstable_raw")]
+#[derive(Clone, Debug)]
+pub enum RawChat {
+    User(tl::types::User),
+    Group(tl::enums::Chat),
+    Channel(tl::types::Channel),
+}
+
 impl Chat {
     pub(crate) fn from_user(user: tl::enums::User) -> Self {
         Self::User(User::from_raw(user))
@@ -169,6 +177,15 @@ impl Chat {
                 (m @ true, Some(ah)) => Some((m, ah)),
                 _ => None,
             },
+        }
+    }
+
+    #[cfg(feature = "unstable_raw")]
+    pub fn as_raw(&self) -> RawChat {
+        match self {
+            Chat::User(user) => RawChat::User(user.0.clone()),
+            Chat::Group(group) => RawChat::Group(group.0.clone()),
+            Chat::Channel(channel) => RawChat::Channel(channel.0.clone()),
         }
     }
 }

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -56,6 +56,20 @@ pub enum Media {
     Poll(Poll),
 }
 
+#[cfg(feature = "unstable_raw")]
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RawMedia {
+    RawPhoto(tl::types::MessageMediaPhoto),
+    RawDocument(tl::types::MessageMediaDocument),
+    RawSticker(
+        tl::types::MessageMediaDocument,
+        tl::types::DocumentAttributeSticker,
+    ),
+    RawContact(tl::types::MessageMediaContact),
+    RawPoll(tl::types::Poll, tl::types::PollResults),
+}
+
 impl Photo {
     pub(crate) fn from_raw(photo: tl::enums::Photo, client: Client) -> Self {
         Self {
@@ -518,6 +532,19 @@ impl Media {
             Media::Sticker(sticker) => sticker.document.to_input_location(),
             Media::Contact(_) => None,
             Media::Poll(_) => None,
+        }
+    }
+
+    #[cfg(feature = "unstable_raw")]
+    pub fn as_raw(&self) -> RawMedia {
+        match self {
+            Media::Photo(photo) => RawMedia::RawPhoto(photo.photo.clone()),
+            Media::Document(document) => RawMedia::RawDocument(document.document.clone()),
+            Media::Sticker(sticker) => {
+                RawMedia::RawSticker(sticker.document.document.clone(), sticker.attrs.clone())
+            }
+            Media::Contact(contact) => RawMedia::RawContact(contact.contact.clone()),
+            Media::Poll(poll) => RawMedia::RawPoll(poll.poll.clone(), poll.results.clone()),
         }
     }
 }

--- a/lib/grammers-client/src/types/message.rs
+++ b/lib/grammers-client/src/types/message.rs
@@ -538,6 +538,11 @@ impl Message {
 
         None
     }
+
+    #[cfg(feature = "unstable_raw")]
+    pub fn as_raw(&self) -> (tl::types::Message, Option<tl::enums::MessageAction>) {
+        (self.msg.clone(), self.action.clone())
+    }
 }
 
 impl fmt::Debug for Message {

--- a/lib/grammers-client/src/types/terms_of_service.rs
+++ b/lib/grammers-client/src/types/terms_of_service.rs
@@ -37,4 +37,9 @@ impl TermsOfService {
     pub fn minimum_age(&self) -> Option<i32> {
         self.0.min_age_confirm
     }
+
+    #[cfg(feature = "unstable_raw")]
+    pub fn as_raw(&self) -> tl::types::help::TermsOfService {
+        self.0.clone()
+    }
 }


### PR DESCRIPTION
New feature "unstable_raw" has been added which will allow you to access the inner private fields which contain raw TL types.