### PR TITLE
[unstable_raw] make unstable_raw API more consistent

### DIFF
--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -115,11 +115,6 @@ impl Channel {
     pub fn username(&self) -> Option<&str> {
         self.0.username.as_deref()
     }
-
-    #[cfg(feature = "unstable_raw")]
-    pub fn as_raw(&self) -> &tl::types::Channel {
-        &self.0
-    }
 }
 
 impl From<Channel> for PackedChat {
@@ -131,5 +126,12 @@ impl From<Channel> for PackedChat {
 impl From<&Channel> for PackedChat {
     fn from(chat: &Channel) -> Self {
         chat.pack()
+    }
+}
+
+#[cfg(feature = "unstable_raw")]
+impl From<Channel> for tl::types::Channel {
+    fn from(channel: Channel) -> Self {
+        channel.0
     }
 }

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -130,11 +130,6 @@ impl Group {
             C::Channel(_) | C::ChannelForbidden(_) => true,
         }
     }
-
-    #[cfg(feature = "unstable_raw")]
-    pub fn as_raw(&self) -> &tl::enums::Chat {
-        &self.0
-    }
 }
 
 impl From<Group> for PackedChat {
@@ -146,5 +141,12 @@ impl From<Group> for PackedChat {
 impl From<&Group> for PackedChat {
     fn from(chat: &Group) -> Self {
         chat.pack()
+    }
+}
+
+#[cfg(feature = "unstable_raw")]
+impl From<Group> for tl::enums::Chat {
+    fn from(group: Group) -> Self {
+        group.0
     }
 }

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -275,11 +275,6 @@ impl User {
     pub fn lang_code(&self) -> Option<&str> {
         self.0.lang_code.as_deref()
     }
-
-    #[cfg(feature = "unstable_raw")]
-    pub fn as_raw(&self) -> &tl::types::User {
-        &self.0
-    }
 }
 
 impl From<User> for PackedChat {
@@ -291,5 +286,12 @@ impl From<User> for PackedChat {
 impl From<&User> for PackedChat {
     fn from(chat: &User) -> Self {
         chat.pack()
+    }
+}
+
+#[cfg(feature = "unstable_raw")]
+impl From<User> for tl::types::User {
+    fn from(user: User) -> Self {
+        user.0
     }
 }


### PR DESCRIPTION
- Remove `as_raw` functions from Chat, Group and User
- Add `From<>` implementations from Chat, Group and User to corresponding raw types