### PR TITLE
Fix panic on IO errors in connect_sender

### DIFF
--- a/lib/grammers-client/src/client/net.rs
+++ b/lib/grammers-client/src/client/net.rs
@@ -343,7 +343,10 @@ impl Client {
                 mutex.insert(dc_id, new_downloader.clone());
                 Ok(new_downloader.clone())
             }
-            Err(e) => panic!("Cannot obtain new sender to datacenter {}", e),
+            Err(AuthorizationError::Invoke(e)) => Err(e),
+            Err(AuthorizationError::Gen(e)) => {
+                panic!("authorization key generation failed: {}", e)
+            }
         }
     }
 


### PR DESCRIPTION
Replaces `Cannot obtain new sender to datacenter authorization error: request error` panic with error propagation