### PR TITLE
Add a WebPage media type

### DIFF
--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -254,7 +254,7 @@ impl InputMessage {
     ///
     /// You can use this to send media from another message without re-uploading it.
     pub fn copy_media(mut self, media: &Media) -> Self {
-        self.media = Some(media.to_input_media());
+        self.media = media.to_input_media();
         self
     }
 

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -69,6 +69,11 @@ pub struct GeoLive {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct WebPage {
+    webpage: tl::types::MessageMediaWebPage,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Media {
     Photo(Photo),
@@ -80,6 +85,7 @@ pub enum Media {
     Dice(Dice),
     Venue(Venue),
     GeoLive(GeoLive),
+    WebPage(WebPage),
 }
 
 impl Photo {
@@ -773,6 +779,22 @@ impl GeoLive {
     }
 }
 
+impl WebPage {
+    fn _from_media(webpage: tl::types::MessageMediaWebPage) -> Self {
+        Self { webpage }
+    }
+
+    #[cfg(not(feature = "unstable_raw"))]
+    pub(crate) fn from_media(webpage: tl::types::MessageMediaWebPage) -> Self {
+        Self::_from_media(webpage)
+    }
+
+    #[cfg(feature = "unstable_raw")]
+    pub fn from_media(webpage: tl::types::MessageMediaWebPage) -> Self {
+        Self::_from_media(webpage)
+    }
+}
+
 impl Uploaded {
     fn _from_raw(input_file: tl::enums::InputFile) -> Self {
         Self { input_file }
@@ -815,7 +837,7 @@ impl Media {
                     Self::Document(document)
                 })
             }
-            M::WebPage(_) => None,
+            M::WebPage(webpage) => Some(Self::WebPage(WebPage::from_media(webpage))),
             M::Venue(venue) => Some(Self::Venue(Venue::from_media(venue))),
             M::Game(_) => None,
             M::Invoice(_) => None,
@@ -835,17 +857,18 @@ impl Media {
         Self::_from_raw(media, client)
     }
 
-    pub(crate) fn to_input_media(&self) -> tl::enums::InputMedia {
+    pub(crate) fn to_input_media(&self) -> Option<tl::enums::InputMedia> {
         match self {
-            Media::Photo(photo) => photo.to_input_media().into(),
-            Media::Document(document) => document.to_input_media().into(),
-            Media::Sticker(sticker) => sticker.document.to_input_media().into(),
-            Media::Contact(contact) => contact.to_input_media().into(),
-            Media::Poll(poll) => poll.to_input_media().into(),
-            Media::Geo(geo) => geo.to_input_media().into(),
-            Media::Dice(dice) => dice.to_input_media().into(),
-            Media::Venue(venue) => venue.to_input_media().into(),
-            Media::GeoLive(geolive) => geolive.to_input_media().into(),
+            Media::Photo(photo) => Some(photo.to_input_media().into()),
+            Media::Document(document) => Some(document.to_input_media().into()),
+            Media::Sticker(sticker) => Some(sticker.document.to_input_media().into()),
+            Media::Contact(contact) => Some(contact.to_input_media().into()),
+            Media::Poll(poll) => Some(poll.to_input_media().into()),
+            Media::Geo(geo) => Some(geo.to_input_media().into()),
+            Media::Dice(dice) => Some(dice.to_input_media().into()),
+            Media::Venue(venue) => Some(venue.to_input_media().into()),
+            Media::GeoLive(geolive) => Some(geolive.to_input_media().into()),
+            Media::WebPage(_) => None,
         }
     }
 
@@ -860,6 +883,7 @@ impl Media {
             Media::Dice(_) => None,
             Media::Venue(_) => None,
             Media::GeoLive(_) => None,
+            Media::WebPage(_) => None,
         }
     }
 }
@@ -893,6 +917,7 @@ impl From<Media> for tl::enums::MessageMedia {
             Media::Dice(dice) => dice.dice.into(),
             Media::Venue(venue) => venue.venue.into(),
             Media::GeoLive(geolive) => geolive.geolive.into(),
+            Media::WebPage(webpage) => webpage.webpage.into(),
         }
     }
 }


### PR DESCRIPTION
This doesn't yet expose anything besides the fact that such media type exists.

One potentially problematic API detail is the fact that Webpage cannot be made into an `InputMedia`, so the `copy_media` will silently ignore to attach such media type.

