### PR TITLE
Add check if media downloadable

### DIFF
--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -172,6 +172,9 @@ impl Client {
                 }
             }
         }
+        if downloadable.to_input_location().is_none() {
+            return Err(io::Error::new(io::ErrorKind::Other, "media not downloadable"));
+        }
 
         let mut download = self.iter_download(downloadable);
         Client::load(path, &mut download).await

--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -173,7 +173,10 @@ impl Client {
             }
         }
         if downloadable.to_input_location().is_none() {
-            return Err(io::Error::new(io::ErrorKind::Other, "media not downloadable"));
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "media not downloadable",
+            ));
         }
 
         let mut download = self.iter_download(downloadable);


### PR DESCRIPTION
Aims to fix #216 . Tested with code:

```rs

// If there's a error, propagates it back to the caller.
let download = message.download_media(&path).await?;

// OR

if let Ok(to_download) = message.download_media(&path).await {
    if to_download {
        // Media was there to download
    }
}

// OR

let download = message.download_media(&path).await;
if download.is_ok() && download.unwrap() {
    // Media was there to download
}


```

I suppose that there is no need to change the description for `client.download_media()`. Users must implement error handling and not call `.unwrap()` directly.