### PR TITLE
Some fixes related to voice media attributes, `mod parsers` and scheduled message

### DIFF
--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -60,10 +60,9 @@ fn map_random_ids_to_messages(
                         message,
                         ..
                     }) => Some(message),
-                    tl::enums::Update::NewScheduledMessage(tl::types::UpdateNewScheduledMessage { 
-                        message, 
-                        ..
-                    }) => Some(message),
+                    tl::enums::Update::NewScheduledMessage(
+                        tl::types::UpdateNewScheduledMessage { message, .. },
+                    ) => Some(message),
                     _ => None,
                 })
                 .filter_map(|message| Message::new(client, message, &chats))

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -60,6 +60,10 @@ fn map_random_ids_to_messages(
                         message,
                         ..
                     }) => Some(message),
+                    tl::enums::Update::NewScheduledMessage(tl::types::UpdateNewScheduledMessage { 
+                        message, 
+                        ..
+                    }) => Some(message),
                     _ => None,
                 })
                 .filter_map(|message| Message::new(client, message, &chats))

--- a/lib/grammers-client/src/lib.rs
+++ b/lib/grammers-client/src/lib.rs
@@ -37,7 +37,10 @@
 //! [Telegram Bot API]: https://core.telegram.org/bots/api
 //! [obtain a developer API ID]: https://my.telegram.org/auth
 pub mod client;
+#[cfg(not(feature = "unstable_raw"))]
 mod parsers;
+#[cfg(feature = "unstable_raw")]
+pub mod parsers;
 pub mod types;
 pub(crate) mod utils;
 

--- a/lib/grammers-client/src/types/attributes.rs
+++ b/lib/grammers-client/src/types/attributes.rs
@@ -44,7 +44,7 @@ impl From<Attribute> for tl::enums::DocumentAttribute {
                 waveform: None,
             }),
             Voice { duration, waveform } => Self::Audio(tl::types::DocumentAttributeAudio {
-                voice: false,
+                voice: true,
                 duration: duration.as_secs().try_into().unwrap(),
                 title: None,
                 performer: None,


### PR DESCRIPTION
- Fixed the voice attribute for sending Voice Media
- Modifying visibility of `mod parsers`; requires feature flag `unstable_raw` to access it publicly.
- After sending a scheduled message, on fetching the update the `Client::send_message` panics due to unwrap on `None` value. Adding the support for `NewScheduledMessage` update fixes this.