### PR TITLE
remove useless `unsafe impl {Send, Sync}`

### DIFF
--- a/lib/grammers-mtsender/src/reconnection.rs
+++ b/lib/grammers-mtsender/src/reconnection.rs
@@ -49,11 +49,3 @@ impl ReconnectionPolicy for NoReconnect {
         ControlFlow::Break(())
     }
 }
-
-unsafe impl Send for NoReconnect {}
-
-unsafe impl Sync for NoReconnect {}
-
-unsafe impl Send for FixedReconnect {}
-
-unsafe impl Sync for FixedReconnect {}


### PR DESCRIPTION
These structs implement `Send + Sync` automatically.