### PR TITLE
Fixed invite link parsing

### DIFF
--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -763,7 +763,7 @@ impl Client {
         if !hosts.contains(&host) {
             return None;
         }
-        let paths = path.split("/").collect::<Vec<&str>>();
+        let paths = path.split("/").skip(1).collect::<Vec<&str>>();
 
         if paths.len() == 1 {
             if paths[0].starts_with("+") {


### PR DESCRIPTION
From the [documentation of url](https://docs.rs/url/latest/url/) we can see that path always stars with / which means that paths[0] is always empty, so we just skip it. I don't know if we need to check if paths.len() is nonzero, but that was also an issue before, so I didn't introduce new issues.