### PR TITLE
remove redundant client in Media::Photo and Media::Document

### DIFF
--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -293,12 +293,8 @@ impl ProfilePhotoIter {
                     iter.request.offset += photos.len() as i32;
                 }
 
-                let client = &iter.client;
-                iter.buffer.extend(
-                    photos
-                        .into_iter()
-                        .map(|x| Photo::from_raw(x, client.clone())),
-                );
+                iter.buffer
+                    .extend(photos.into_iter().map(|x| Photo::from_raw(x)));
 
                 Ok(total)
             }
@@ -325,7 +321,7 @@ impl ProfilePhotoIter {
                         tl::types::MessageActionChatEditPhoto { photo },
                     )) = message.raw_action
                     {
-                        return Ok(Some(Photo::from_raw(photo, message.client.clone())));
+                        return Ok(Some(Photo::from_raw(photo)));
                     } else {
                         continue;
                     }

--- a/lib/grammers-client/src/types/media.rs
+++ b/lib/grammers-client/src/types/media.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use crate::types::photo_sizes::{PhotoSize, VecExt};
-use crate::Client;
 use chrono::{DateTime, Utc};
 use grammers_tl_types as tl;
 use std::fmt::Debug;
@@ -14,13 +13,11 @@ use std::fmt::Debug;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Photo {
     pub raw: tl::types::MessageMediaPhoto,
-    client: Client,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Document {
     pub raw: tl::types::MessageMediaDocument,
-    client: Client,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -89,19 +86,18 @@ pub enum Media {
 }
 
 impl Photo {
-    pub fn from_raw(photo: tl::enums::Photo, client: Client) -> Self {
+    pub fn from_raw(photo: tl::enums::Photo) -> Self {
         Self {
             raw: tl::types::MessageMediaPhoto {
                 spoiler: false,
                 photo: Some(photo),
                 ttl_seconds: None,
             },
-            client,
         }
     }
 
-    pub fn from_raw_media(photo: tl::types::MessageMediaPhoto, client: Client) -> Self {
-        Self { raw: photo, client }
+    pub fn from_raw_media(photo: tl::types::MessageMediaPhoto) -> Self {
+        Self { raw: photo }
     }
 
     pub fn to_raw_input_location(&self) -> Option<tl::enums::InputFileLocation> {
@@ -204,11 +200,8 @@ impl Photo {
 }
 
 impl Document {
-    pub fn from_raw_media(document: tl::types::MessageMediaDocument, client: Client) -> Self {
-        Self {
-            raw: document,
-            client,
-        }
+    pub fn from_raw_media(document: tl::types::MessageMediaDocument) -> Self {
+        Self { raw: document }
     }
 
     pub fn to_raw_input_location(&self) -> Option<tl::enums::InputFileLocation> {
@@ -738,18 +731,18 @@ impl Uploaded {
 }
 
 impl Media {
-    pub fn from_raw(media: tl::enums::MessageMedia, client: Client) -> Option<Self> {
+    pub fn from_raw(media: tl::enums::MessageMedia) -> Option<Self> {
         use tl::enums::MessageMedia as M;
 
         // TODO implement the rest
         match media {
             M::Empty => None,
-            M::Photo(photo) => Some(Self::Photo(Photo::from_raw_media(photo, client))),
+            M::Photo(photo) => Some(Self::Photo(Photo::from_raw_media(photo))),
             M::Geo(geo) => Geo::from_raw_media(geo).map(Self::Geo),
             M::Contact(contact) => Some(Self::Contact(Contact::from_raw_media(contact))),
             M::Unsupported => None,
             M::Document(document) => {
-                let document = Document::from_raw_media(document, client);
+                let document = Document::from_raw_media(document);
                 Some(if let Some(sticker) = Sticker::from_document(&document) {
                     Self::Sticker(sticker)
                 } else {

--- a/lib/grammers-client/src/types/message.rs
+++ b/lib/grammers-client/src/types/message.rs
@@ -337,10 +337,7 @@ impl Message {
     /// This not only includes photos or videos, but also contacts, polls, documents, locations
     /// and many other types.
     pub fn media(&self) -> Option<types::Media> {
-        self.raw
-            .media
-            .clone()
-            .and_then(|x| Media::from_raw(x, self.client.clone()))
+        self.raw.media.clone().and_then(|x| Media::from_raw(x))
     }
 
     /// If the message has a reply markup (which can happen for messages produced by bots),


### PR DESCRIPTION
`client` in `Media::Photo` and `Media::Document` can be removed after #251.