### PR TITLE
Add fake TG_ID and TG_HASH in env config to avoid error message in example.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+TG_ID = ""
+TG_HASH = ""


### PR DESCRIPTION
`.cargo/config.toml` in `grammers` only affect `grammers` developers.

To users there's no difference.