### PR TITLE
feat: support usernames for chat

### DIFF
--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -130,6 +130,26 @@ impl Channel {
         self.raw.username.as_deref()
     }
 
+    /// Return collectible usernames of this chat, if any.
+    ///
+    /// The returned usernames do not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of its username, such
+    /// as https://t.me/username.
+    pub fn usernames(&self) -> Vec<&str> {
+        self.raw
+            .usernames
+            .as_deref()
+            .map_or(Vec::new(), |usernames| {
+                usernames
+                    .iter()
+                    .map(|username| match username {
+                        tl::enums::Username::Username(username) => username.username.as_ref(),
+                    })
+                    .collect()
+            })
+    }
+
     /// Return the photo of this channel, if any.
     pub fn photo(&self) -> Option<&tl::types::ChatPhoto> {
         match &self.raw.photo {

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -121,6 +121,37 @@ impl Group {
         }
     }
 
+    /// Return collectible usernames of this chat, if any.
+    ///
+    /// The returned usernames do not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of its username, such
+    /// as https://t.me/username.
+    pub fn usernames(&self) -> Vec<&str> {
+        use tl::enums::Chat;
+
+        match &self.raw {
+            Chat::Empty(_) | Chat::Chat(_) | Chat::Forbidden(_) | Chat::ChannelForbidden(_) => {
+                Vec::new()
+            }
+            Chat::Channel(channel) => {
+                channel
+                    .usernames
+                    .as_deref()
+                    .map_or(Vec::new(), |usernames| {
+                        usernames
+                            .iter()
+                            .map(|username| match username {
+                                tl::enums::Username::Username(username) => {
+                                    username.username.as_ref()
+                                }
+                            })
+                            .collect()
+                    })
+            }
+        }
+    }
+
     // Return photo of this group, if any.
     pub fn photo(&self) -> Option<&tl::types::ChatPhoto> {
         match &self.raw {

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -157,6 +157,20 @@ impl Chat {
         }
     }
 
+    /// Return collectible usernames of this chat, if any.
+    ///
+    /// The returned usernames do not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of its username, such
+    /// as https://t.me/username.
+    pub fn usernames(&self) -> Vec<&str> {
+        match self {
+            Self::User(user) => user.usernames(),
+            Self::Group(group) => group.usernames(),
+            Self::Channel(channel) => channel.usernames(),
+        }
+    }
+
     // If `Self` has `min` `access_hash`, returns a mutable reference to both `min` and `access_hash`.
     //
     // This serves as a way of checking "is it min?" and "update the access hash" both in one.

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -198,6 +198,26 @@ impl User {
         self.raw.username.as_deref()
     }
 
+    /// Return collectible usernames of this chat, if any.
+    ///
+    /// The returned usernames do not contain the "@" prefix.
+    ///
+    /// Outside of the application, people may link to this user with one of its username, such
+    /// as https://t.me/username.
+    pub fn usernames(&self) -> Vec<&str> {
+        self.raw
+            .usernames
+            .as_deref()
+            .map_or(Vec::new(), |usernames| {
+                usernames
+                    .iter()
+                    .map(|username| match username {
+                        tl::enums::Username::Username(username) => username.username.as_ref(),
+                    })
+                    .collect()
+            })
+    }
+
     /// Return the phone number of this user, if they are not a bot and their privacy settings
     /// allow you to see it.
     pub fn phone(&self) -> Option<&str> {


### PR DESCRIPTION
When using username to find a chat, the `username` may be `None` if there are `usernames`.

See https://core.telegram.org/api/fragment