### PR TITLE
Cover `UploadedPhoto` and `UploadedDocument`

### DIFF
--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -583,7 +583,9 @@ impl Client {
 
             if matches!(
                 raw_media,
-                tl::enums::InputMedia::PhotoExternal(_)
+                tl::enums::InputMedia::UploadedPhoto(_)
+                    | tl::enums::InputMedia::PhotoExternal(_)
+                    | tl::enums::InputMedia::UploadedDocument(_)
                     | tl::enums::InputMedia::DocumentExternal(_)
             ) {
                 let uploaded = self


### PR DESCRIPTION
If not covered, Telegram throws `rpc error 400: MEDIA_INVALID caused by messages.sendMultiMedia`