### PR TITLE
Fix container requests never returning on failure

### DIFF
--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -137,7 +137,7 @@ struct Request {
     result: oneshot::Sender<Result<Vec<u8>, InvocationError>>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct MsgIdPair {
     msg_id: MsgId,
     container_msg_id: MsgId,
@@ -444,7 +444,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
         if let Some(container_msg_id) = self.mtp.finalize(&mut self.write_buffer) {
             for request in self.requests.iter_mut() {
                 match request.state {
-                    RequestState::Serialized(mut pair) => {
+                    RequestState::Serialized(ref mut pair) => {
                         pair.container_msg_id = container_msg_id;
                     }
                     RequestState::NotSerialized | RequestState::Sent(..) => {}
@@ -515,11 +515,11 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
         self.write_buffer.clear();
         self.write_head = 0;
         for req in self.requests.iter_mut() {
-            match req.state {
+            match &req.state {
                 RequestState::NotSerialized | RequestState::Sent(_) => {}
                 RequestState::Serialized(pair) => {
                     debug!("sent request with {:?}", pair);
-                    req.state = RequestState::Sent(pair);
+                    req.state = RequestState::Sent(pair.clone());
                 }
             }
         }
@@ -691,7 +691,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
 
     fn process_bad_message(&mut self, bad_msg: BadMessage) {
         for i in (0..self.requests.len()).rev() {
-            match self.requests[i].state {
+            match &self.requests[i].state {
                 RequestState::Serialized(pair)
                     if pair.msg_id == bad_msg.msg_id || pair.container_msg_id == bad_msg.msg_id =>
                 {
@@ -754,7 +754,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
 
     fn pop_request(&mut self, msg_id: MsgId) -> Option<Request> {
         for i in 0..self.requests.len() {
-            match self.requests[i].state {
+            match &self.requests[i].state {
                 RequestState::Serialized(pair) if pair.msg_id == msg_id => {
                     panic!("got response {msg_id:?} for unsent request {pair:?}");
                 }


### PR DESCRIPTION
## Description:
This PR fixes the notorious issue that caused some requests to never return.
This might also fix #237 but I'm not sure.
## What was causing the bug:
The issue occurred when several messages were in the requests queue and the salts were also invalidated. Technically, any bad message notification when using containers could trigger it, but these are rare outside of bad salt errors. The root of the problem was that the code responsible for updating the container IDs after sending a container request was implicitly copying the `MsgIdPair` and assigning the container message ID to a local copy, which was later dropped.
## Changes made:
- `MsgIdPair` is no longer `Copy`. This would prevent issues like this from happening in the future as well.
- The part handling sending requests is now changed to use a mutable reference ensuring it actually updates the container IDs. 