### PR TITLE
Signal client to refetch updates upon reconnect

### DIFF
--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -572,7 +572,10 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                             .iter_mut()
                             .for_each(|r| r.state = RequestState::NotSerialized);
 
-                        return Ok(Vec::new());
+                        // We'll return a TooLong update to signal to the client
+                        // that it needs to call getDifference and query the server
+                        // for new updates again.
+                        return Ok(vec![tl::enums::Updates::TooLong]);
                     }
                     Err(e) => ReadError::from(e),
                 }


### PR DESCRIPTION
Fixes #274 as the chat names issue is normal behavior anyways.
## Description:
There isn't really much left to discuss as it's a relatively small and self-explanatory change. A successful reconnection now causes a new `TooLong` update. This signals the client that it needs to call `getDifference` again to refetch any missed or future updates.

This is particularly useful in networks where a proxy holds the connection open for a short time after user disconnection, causing some updates to be temporarily lost.
This should also remove the need for workarounds where the user needed to make an RPC call to "stimulate" the client to receive updates again as it does so automatically now.
