### PR TITLE
Add serde support for tl_types.

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -18,6 +18,7 @@ markdown = ["pulldown-cmark"]
 html = ["html5ever"]
 proxy = ["grammers-mtsender/proxy"]
 parse_invite_link = ["url"]
+serde = ["grammers-tl-types/impl-serde"]
 
 [dependencies]
 chrono = "0.4.38"

--- a/lib/grammers-tl-gen/src/enums.rs
+++ b/lib/grammers-tl-gen/src/enums.rs
@@ -37,7 +37,9 @@ fn write_enum<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
-    writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    if config.impl_serde{
+        writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    }
 
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;
     writeln!(

--- a/lib/grammers-tl-gen/src/enums.rs
+++ b/lib/grammers-tl-gen/src/enums.rs
@@ -37,8 +37,11 @@ fn write_enum<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
-    if config.impl_serde{
-        writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    if config.impl_serde {
+        writeln!(
+            file,
+            "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]"
+        )?;
     }
 
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;

--- a/lib/grammers-tl-gen/src/enums.rs
+++ b/lib/grammers-tl-gen/src/enums.rs
@@ -37,6 +37,8 @@ fn write_enum<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
+    writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;
     writeln!(
         file,

--- a/lib/grammers-tl-gen/src/lib.rs
+++ b/lib/grammers-tl-gen/src/lib.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub impl_debug: bool,
     pub impl_from_type: bool,
     pub impl_from_enum: bool,
+    pub impl_serde: bool,
 }
 
 impl Default for Config {
@@ -36,6 +37,7 @@ impl Default for Config {
             impl_debug: true,
             impl_from_type: true,
             impl_from_enum: true,
+            impl_serde: false,
         }
     }
 }

--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -63,7 +63,9 @@ fn write_struct<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
-    writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    if config.impl_serde{
+        writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    }
 
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;
     write!(

--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -81,11 +81,14 @@ fn write_struct<W: Write>(
 
     writeln!(file)?;
     for param in def.params.iter() {
-        match param.ty {
+        match &param.ty {
             ParameterType::Flags => {
                 // Flags are computed on-the-fly, not stored
             }
-            ParameterType::Normal { .. } => {
+            ParameterType::Normal { ty, .. } => {
+                if config.impl_serde && ty.name.as_str() == "bytes" {
+                    writeln!(file, "{}    #[serde(with = \"serde_bytes\")]", indent)?;
+                }
                 writeln!(
                     file,
                     "{}    pub {}: {},",

--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -63,6 +63,8 @@ fn write_struct<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
+    writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;
     write!(
         file,

--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -63,8 +63,11 @@ fn write_struct<W: Write>(
         writeln!(file, "{indent}#[derive(Debug)]")?;
     }
 
-    if config.impl_serde{
-        writeln!(file, "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]")?;
+    if config.impl_serde {
+        writeln!(
+            file,
+            "{indent}#[derive(serde_derive::Serialize, serde_derive::Deserialize)]"
+        )?;
     }
 
     writeln!(file, "{indent}#[derive(Clone, PartialEq)]")?;

--- a/lib/grammers-tl-gen/tests/lib.rs
+++ b/lib/grammers-tl-gen/tests/lib.rs
@@ -28,6 +28,7 @@ fn gen_rust_code(definitions: &[Definition]) -> io::Result<String> {
             impl_debug: true,
             impl_from_enum: true,
             impl_from_type: true,
+            impl_serde: true,
         },
     )?;
     Ok(String::from_utf8(file).unwrap())

--- a/lib/grammers-tl-gen/tests/lib.rs
+++ b/lib/grammers-tl-gen/tests/lib.rs
@@ -132,7 +132,7 @@ fn generic_bytes_with_serde_bytes() -> io::Result<()> {
 
     let result = gen_rust_code(&definitions)?;
     eprintln!("{result}");
-    assert!(result.contains(r#"#[serde(with="serde_bytes")]"#));
+    assert!(result.contains(r#"#[serde(with = "serde_bytes")]"#));
     assert!(result.contains("pub stripped_thumb: Option<Vec<u8>>,"));
     Ok(())
 }

--- a/lib/grammers-tl-gen/tests/lib.rs
+++ b/lib/grammers-tl-gen/tests/lib.rs
@@ -120,3 +120,19 @@ fn recursive_types_vec_indirect_not_boxed() -> io::Result<()> {
     assert!(result.contains("JsonObject(crate::types::JsonObject)"));
     Ok(())
 }
+
+#[test]
+fn generic_bytes_with_serde_bytes() -> io::Result<()> {
+    let definitions = get_definitions(
+        r#"
+        chatPhotoEmpty#37c1011c = ChatPhoto;
+        chatPhoto#1c6e1c11 flags:# has_video:flags.0?true photo_id:long stripped_thumb:flags.1?bytes dc_id:int = ChatPhoto;
+        "#,
+    );
+
+    let result = gen_rust_code(&definitions)?;
+    eprintln!("{result}");
+    assert!(result.contains(r#"#[serde(with="serde_bytes")]"#));
+    assert!(result.contains("pub stripped_thumb: Option<Vec<u8>>,"));
+    Ok(())
+}

--- a/lib/grammers-tl-types/Cargo.toml
+++ b/lib/grammers-tl-types/Cargo.toml
@@ -32,9 +32,10 @@ deserializable-functions = []
 impl-debug = []
 impl-from-enum = []
 impl-from-type = []
+impl-serde = ["dep:serde", "dep:serde_derive"]
 tl-api = []
 tl-mtproto = []
 
 [dependencies]
-serde = "1.0.210"
-serde_derive = "1.0.210"
+serde = { version = "1.0.210", optional = true }
+serde_derive = { version = "1.0.210", optional = true }

--- a/lib/grammers-tl-types/Cargo.toml
+++ b/lib/grammers-tl-types/Cargo.toml
@@ -34,3 +34,7 @@ impl-from-enum = []
 impl-from-type = []
 tl-api = []
 tl-mtproto = []
+
+[dependencies]
+serde = "1.0.210"
+serde_derive = "1.0.210"

--- a/lib/grammers-tl-types/Cargo.toml
+++ b/lib/grammers-tl-types/Cargo.toml
@@ -32,10 +32,11 @@ deserializable-functions = []
 impl-debug = []
 impl-from-enum = []
 impl-from-type = []
-impl-serde = ["dep:serde", "dep:serde_derive"]
+impl-serde = ["dep:serde", "dep:serde_derive", "dep:serde_bytes"]
 tl-api = []
 tl-mtproto = []
 
 [dependencies]
 serde = { version = "1.0.210", optional = true }
+serde_bytes = { version = "0.11.15", optional = true }
 serde_derive = { version = "1.0.210", optional = true }

--- a/lib/grammers-tl-types/DEPS.md
+++ b/lib/grammers-tl-types/DEPS.md
@@ -11,3 +11,11 @@ Used to parse the `.tl` files provided by Telegram's open source projects.
 ## toml
 
 Used to test that this file lists all dependencies from `Cargo.toml`.
+
+## serde
+
+Support serde ecosystem.
+
+## serde_derive
+
+Macros that auto generate serde code.

--- a/lib/grammers-tl-types/DEPS.md
+++ b/lib/grammers-tl-types/DEPS.md
@@ -19,3 +19,7 @@ Support serde ecosystem.
 ## serde_derive
 
 Macros that auto generate serde code.
+
+## serde_bytes
+
+Use better bytes encode/decode pattern in serde.

--- a/lib/grammers-tl-types/build.rs
+++ b/lib/grammers-tl-types/build.rs
@@ -76,6 +76,7 @@ fn main() -> std::io::Result<()> {
         impl_debug: cfg!(feature = "impl-debug"),
         impl_from_enum: cfg!(feature = "impl-from-enum"),
         impl_from_type: cfg!(feature = "impl-from-type"),
+        impl_serde: cfg!(feature = "impl-serde"),
     };
 
     generate_rust_code(&mut file, &definitions, layer, &config)?;

--- a/lib/grammers-tl-types/src/lib.rs
+++ b/lib/grammers-tl-types/src/lib.rs
@@ -67,6 +67,8 @@
 //! * `tl-mtproto`: generates code for the `mtproto.tl`.
 //!   Only useful for low-level libraries.
 //!
+//! * `impl-serde`: generates code for serde support
+//! 
 //! [`types`]: types/index.html
 //! [`functions`]: functions/index.html
 //! [`RemoteCall`]: trait.RemoteCall.html

--- a/lib/grammers-tl-types/src/lib.rs
+++ b/lib/grammers-tl-types/src/lib.rs
@@ -84,17 +84,22 @@ pub use deserialize::{Cursor, Deserializable};
 pub use generated::{enums, functions, name_for_id, types, LAYER};
 pub use serialize::Serializable;
 
+#[cfg(feature = "impl-serde")]
+use serde_derive::{Deserialize, Serialize};
+
 /// This struct represents the concrete type of a vector, that is,
 /// `vector` as opposed to the type `Vector`. This bare type is less
 /// common, so instead of creating a enum for `Vector` wrapping `vector`
 /// as Rust's `Vec` (as we would do with auto-generated code),
 /// a new-type for `vector` is used instead.
+#[cfg_attr(feature = "impl-serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RawVec<T>(pub Vec<T>);
 
 /// This struct represents an unparsed blob, which should not be deserialized
 /// as a bytes string. Used by functions returning generic objects which pass
 /// the underlying result without any modification or interpretation.
+#[cfg_attr(feature = "impl-serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Blob(pub Vec<u8>);
 

--- a/lib/grammers-tl-types/src/lib.rs
+++ b/lib/grammers-tl-types/src/lib.rs
@@ -68,7 +68,7 @@
 //!   Only useful for low-level libraries.
 //!
 //! * `impl-serde`: generates code for serde support
-//! 
+//!
 //! [`types`]: types/index.html
 //! [`functions`]: functions/index.html
 //! [`RemoteCall`]: trait.RemoteCall.html
@@ -103,7 +103,7 @@ pub struct RawVec<T>(pub Vec<T>);
 /// the underlying result without any modification or interpretation.
 #[cfg_attr(feature = "impl-serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
-pub struct Blob(pub Vec<u8>);
+pub struct Blob(#[cfg_attr(feature = "impl-serde", serde(with = "serde_bytes"))] pub Vec<u8>);
 
 impl From<Vec<u8>> for Blob {
     fn from(value: Vec<u8>) -> Self {


### PR DESCRIPTION
Add two lines for each entrance in generated.rs 
- all enums
- all structs
(Did I miss for other things?)

Pass all tests in crate `grammers-tl-types`