### PR TITLE
Add a method to allow using TL types for media in InputMessage 

### DIFF
--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -187,6 +187,20 @@ impl InputMessage {
         self
     }
 
+    /// Include a media in the message using the raw TL types.
+    ///
+    /// You can use this to send any media using the raw TL types that don't have
+    /// a specific method in this builder such as Dice, Polls, etc.
+    ///
+    /// This can also be used to send media with a file reference, see `InputMediaDocument`
+    /// and `InputMediaPhoto` in the `grammers-tl-types` crate.
+    ///
+    /// The text will be the caption of the media, which may be empty for no caption.
+    pub fn media<M: Into<tl::enums::InputMedia>>(mut self, media: M) -> Self {
+        self.media = Some(media.into());
+        self
+    }
+
     /// Include the video file with thumb in the message.
     ///
     /// The text will be the caption of the document, which may be empty for no caption.


### PR DESCRIPTION
Adds two new methods to `InputMessage` , `photo_id` and `document_id`. These new methods allow the user to include media in their messages using `InputPhoto` and `InputDocument` without having to copy the media from a message or re-uploading.