### PR TITLE
deps: trust-dns is no longer maintained, move into hickory-dns

### DIFF
--- a/lib/grammers-mtsender/Cargo.toml
+++ b/lib/grammers-mtsender/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "network-programming"]
 edition = "2021"
 
 [features]
-proxy = ["tokio-socks", "trust-dns-resolver", "url"]
+proxy = ["tokio-socks", "hickory-resolver", "url"]
 
 [dependencies]
 bytes = "1.7.1"
@@ -27,7 +27,7 @@ grammers-tl-types = { path = "../grammers-tl-types", version = "0.7.0", features
 log = "0.4.22"
 tokio = { version = "1.40.0", default-features = false, features = ["net", "io-util", "sync", "time"] }
 tokio-socks = { version = "0.5.2", optional = true }
-trust-dns-resolver = { version = "0.23.2", optional = true }
+hickory-resolver = { version = "0.24.1", optional = true }
 url = { version = "2.5.2", optional = true }
 
 [dev-dependencies]

--- a/lib/grammers-mtsender/DEPS.md
+++ b/lib/grammers-mtsender/DEPS.md
@@ -38,7 +38,7 @@ Used to test that this file lists all dependencies from `Cargo.toml`.
 
 Used to parse the optional proxy URL.
 
-## trust-dns-resolver
+## hickory-resolver
 
 Used to look up the IP address of the proxy host if a domain is provided.
 

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -39,11 +39,11 @@ use tokio::time::{sleep_until, Duration, Instant};
 
 #[cfg(feature = "proxy")]
 use {
+    hickory_resolver::config::{ResolverConfig, ResolverOpts},
+    hickory_resolver::AsyncResolver,
     std::io::ErrorKind,
     std::net::{IpAddr, SocketAddr},
     tokio_socks::tcp::Socks5Stream,
-    trust_dns_resolver::config::{ResolverConfig, ResolverOpts},
-    trust_dns_resolver::AsyncResolver,
     url::Host,
 };
 


### PR DESCRIPTION
See main page of https://github.com/bluejekyll/trust-dns.