### PR TITLE
Remove sentinel values in names

### DIFF
--- a/lib/grammers-client/examples/dialogs.rs
+++ b/lib/grammers-client/examples/dialogs.rs
@@ -93,7 +93,7 @@ async fn async_main() -> Result<()> {
     println!("Showing up to {} dialogs:", dialogs.total().await?);
     while let Some(dialog) = dialogs.next().await? {
         let chat = dialog.chat();
-        println!("- {: >10} {}", chat.id(), chat.name());
+        println!("- {: >10} {}", chat.id(), chat.name().unwrap_or_default());
     }
 
     if sign_out {

--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -27,7 +27,7 @@ async fn handle_update(client: Client, update: Update) -> Result {
         Update::NewMessage(message) if !message.outgoing() => {
             let chat = message.chat();
             println!("Responding to {}", chat.name().unwrap_or(&format!("id {}", chat.id())));
-            //client.send_message(&chat, message.text()).await?;
+            client.send_message(&chat, message.text()).await?;
         }
         _ => {}
     }

--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -26,7 +26,10 @@ async fn handle_update(client: Client, update: Update) -> Result {
     match update {
         Update::NewMessage(message) if !message.outgoing() => {
             let chat = message.chat();
-            println!("Responding to {}", chat.name().unwrap_or(&format!("id {}", chat.id())));
+            println!(
+                "Responding to {}",
+                chat.name().unwrap_or(&format!("id {}", chat.id()))
+            );
             client.send_message(&chat, message.text()).await?;
         }
         _ => {}

--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -26,8 +26,8 @@ async fn handle_update(client: Client, update: Update) -> Result {
     match update {
         Update::NewMessage(message) if !message.outgoing() => {
             let chat = message.chat();
-            println!("Responding to {}", chat.name());
-            client.send_message(&chat, message.text()).await?;
+            println!("Responding to {}", chat.name().unwrap_or(&format!("id {}", chat.id())));
+            //client.send_message(&chat, message.text()).await?;
         }
         _ => {}
     }

--- a/lib/grammers-client/src/client/auth.rs
+++ b/lib/grammers-client/src/client/auth.rs
@@ -136,7 +136,12 @@ impl Client {
     ///     }
     /// };
     ///
-    /// println!("Signed in as {}!", user.first_name());
+    /// if let Some(first_name) = user.first_name() {
+    ///     println!("Signed in as {}!", first_name);
+    /// } else {
+    ///     println!("Signed in!");
+    /// }
+    ///
     /// # Ok(())
     /// # }
     /// ```
@@ -286,7 +291,11 @@ impl Client {
     ///     }
     /// };
     ///
-    /// println!("Signed in as {}!", user.first_name());
+    /// if let Some(first_name) = user.first_name() {
+    ///     println!("Signed in as {}!", first_name);
+    /// } else {
+    ///   println!("Signed in!");
+    /// }
     /// # Ok(())
     /// # }
     /// ```

--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -444,7 +444,11 @@ impl Client {
     /// let mut participants = client.iter_participants(&chat);
     ///
     /// while let Some(participant) = participants.next().await? {
-    ///     println!("{} has role {:?}", participant.user.first_name(), participant.role);
+    ///     println!(
+    ///         "{} has role {:?}",
+    ///         participant.user.first_name().unwrap_or(&participant.user.id().to_string()),
+    ///         participant.role
+    ///     );
     /// }
     /// # Ok(())
     /// # }
@@ -633,7 +637,7 @@ impl Client {
     /// # async fn f(packed_chat: grammers_client::types::chat::PackedChat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// let chat = client.unpack_chat(packed_chat).await?;
     ///
-    /// println!("Found chat: {}", chat.name());
+    /// println!("Found chat: {}", chat.name().unwrap_or(&chat.id().to_string()));
     /// # Ok(())
     /// # }
     /// ```

--- a/lib/grammers-client/src/client/dialogs.rs
+++ b/lib/grammers-client/src/client/dialogs.rs
@@ -150,7 +150,7 @@ impl Client {
     ///
     /// while let Some(dialog) = dialogs.next().await? {
     ///     let chat = dialog.chat();
-    ///     println!("{} ({})", chat.name(), chat.id());
+    ///     println!("{} ({})", chat.name().unwrap_or_default(), chat.id());
     /// }
     /// # Ok(())
     /// # }

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -941,7 +941,8 @@ impl Client {
     /// let mut messages = client.search_messages(&chat).query("grammers is cool");
     ///
     /// while let Some(message) = messages.next().await? {
-    ///     println!("{}", message.sender().unwrap().name());
+    ///     let sender = message.sender().unwrap();
+    ///     println!("{}", sender.name().unwrap_or(&sender.id().to_string()));
     /// }
     /// # Ok(())
     /// # }
@@ -963,7 +964,7 @@ impl Client {
     /// let mut messages = client.search_all_messages().query("grammers is cool");
     ///
     /// while let Some(message) = messages.next().await? {
-    ///     println!("{}", message.chat().name());
+    ///     println!("{}", message.chat().name().unwrap_or(&message.chat().id().to_string()));
     /// }
     /// # Ok(())
     /// # }
@@ -1036,10 +1037,12 @@ impl Client {
     ///
     /// ```
     /// # async fn f(chat: grammers_client::types::Chat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let name = chat.name().map_or(chat.id().to_string(), |name| name.to_owned());
+    ///
     /// if let Some(message) = client.get_pinned_message(&chat).await? {
-    ///     println!("There is a message pinned in {}: {}", chat.name(), message.text());
+    ///     println!("There is a message pinned in {}: {}", name.to_owned(), message.text());
     /// } else {
-    ///     println!("There are no messages pinned in {}", chat.name());
+    ///     println!("There are no messages pinned in {}", name.to_owned());
     /// }
     /// # Ok(())
     /// # }

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -94,15 +94,15 @@ impl Group {
     /// Return the title of this group.
     ///
     /// The title may be the empty string if the group is not accessible.
-    pub fn title(&self) -> &str {
+    pub fn title(&self) -> Option<&str> {
         use tl::enums::Chat;
 
         match &self.raw {
-            Chat::Empty(_) => "",
-            Chat::Chat(chat) => chat.title.as_str(),
-            Chat::Forbidden(chat) => chat.title.as_str(),
-            Chat::Channel(chat) => chat.title.as_str(),
-            Chat::ChannelForbidden(chat) => chat.title.as_str(),
+            Chat::Empty(_) => None,
+            Chat::Chat(chat) => Some(chat.title.as_str()),
+            Chat::Forbidden(chat) => Some(chat.title.as_str()),
+            Chat::Channel(chat) => Some(chat.title.as_str()),
+            Chat::ChannelForbidden(chat) => Some(chat.title.as_str()),
         }
     }
 

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -85,11 +85,11 @@ impl Chat {
     /// this is their title.
     ///
     /// The name may be empty if the chat is inaccessible or if the account was deleted.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> Option<&str> {
         match self {
             Self::User(user) => user.first_name(),
             Self::Group(group) => group.title(),
-            Self::Channel(channel) => channel.title(),
+            Self::Channel(channel) => Some(channel.title()),
         }
     }
 

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -84,7 +84,8 @@ impl Chat {
     /// For private conversations (users), this is their first name. For groups and channels,
     /// this is their title.
     ///
-    /// The name may be empty if the chat is inaccessible or if the account was deleted.
+    /// The name will be `None` if the chat is inaccessible or if the account was deleted. It may
+    /// also be `None` if you received it previously.
     pub fn name(&self) -> Option<&str> {
         match self {
             Self::User(user) => user.first_name(),

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -159,8 +159,8 @@ impl User {
     /// Return the first name of this user.
     ///
     /// If the account was deleted, the returned string will be empty.
-    pub fn first_name(&self) -> &str {
-        self.raw.first_name.as_deref().unwrap_or("")
+    pub fn first_name(&self) -> Option<&str> {
+        self.raw.first_name.as_deref()
     }
 
     /// Return the last name of this user, if any.
@@ -176,7 +176,7 @@ impl User {
     /// This is equal to the user's first name concatenated with the user's last name, if this
     /// is not empty. Otherwise, it equals the user's first name.
     pub fn full_name(&self) -> String {
-        let first_name = self.first_name();
+        let first_name = self.first_name().unwrap_or_default();
         if let Some(last_name) = self.last_name() {
             let mut name = String::with_capacity(first_name.len() + 1 + last_name.len());
             name.push_str(first_name);

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -158,7 +158,8 @@ impl User {
 
     /// Return the first name of this user.
     ///
-    /// If the account was deleted, the returned string will be empty.
+    /// The name will be `None` if the account was deleted. It may also be `None` if you received
+    /// it previously.
     pub fn first_name(&self) -> Option<&str> {
         self.raw.first_name.as_deref()
     }


### PR DESCRIPTION
Functions `Chat::name`, `Chat::User::first_name`, and `Chat::Group::title` have sentinel values, occasionally returning empty strings, which is a bad code practice. The docs also don't mention all the cases when the strings are going to be empty.

Telegram doesn't include all sender information because it assumes you already have it.
_Originally posted by @Lonami in https://github.com/Lonami/grammers/issues/212#issuecomment-1844791353_

This creates confusion, leading to faulty code, as in #274 for example. Using `Option` will make it so users can't accidentally forget to check if the returned string is empty.