### PR TITLE
Migrating to `futures::Stream` for all `iter_*` method

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -22,6 +22,7 @@ serde = ["grammers-tl-types/impl-serde"]
 
 [dependencies]
 chrono = "0.4.38"
+futures = "0.3.31"
 futures-util = { version = "0.3.30", default-features = false, features = [
     "alloc"
 ] }

--- a/lib/grammers-client/DEPS.md
+++ b/lib/grammers-client/DEPS.md
@@ -76,6 +76,10 @@ Used to test that this file lists all dependencies from `Cargo.toml`.
 Used for return custom types that `impl Future` so that the requests can be further configured
 without having to use `Box`.
 
+## futures
+
+Provides Stream functionality
+
 ## futures-util
 
 Provides useful functions for working with futures/tasks.

--- a/lib/grammers-client/examples/dialogs.rs
+++ b/lib/grammers-client/examples/dialogs.rs
@@ -10,6 +10,7 @@
 //! cargo run --example dialogs
 //! ```
 
+use futures::TryStreamExt;
 use grammers_client::session::Session;
 use grammers_client::{Client, Config, SignInError};
 use simple_logger::SimpleLogger;
@@ -88,10 +89,10 @@ async fn async_main() -> Result<()> {
         }
     }
 
-    let mut dialogs = client.iter_dialogs();
+    let mut dialogs = client.stream_dialogs();
 
     println!("Showing up to {} dialogs:", dialogs.total().await?);
-    while let Some(dialog) = dialogs.next().await? {
+    while let Some(dialog) = dialogs.try_next().await? {
         let chat = dialog.chat();
         println!("- {: >10} {}", chat.id(), chat.name().unwrap_or_default());
     }

--- a/lib/grammers-client/examples/downloader.rs
+++ b/lib/grammers-client/examples/downloader.rs
@@ -17,6 +17,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::{env, io};
 
+use futures::TryStreamExt;
 use grammers_client::{Client, Config, SignInError};
 use mime::Mime;
 use mime_guess::mime;
@@ -89,7 +90,7 @@ async fn async_main() -> Result<()> {
 
     let chat = maybe_chat.unwrap_or_else(|| panic!("Chat {chat_name} could not be found"));
 
-    let mut messages = client.iter_messages(&chat);
+    let mut messages = client.stream_messages(&chat);
 
     println!(
         "Chat {} has {} total messages.",
@@ -99,7 +100,7 @@ async fn async_main() -> Result<()> {
 
     let mut counter = 0;
 
-    while let Some(msg) = messages.next().await? {
+    while let Some(msg) = messages.try_next().await? {
         counter += 1;
         println!("Message {}:{}", msg.id(), msg.text());
         if let Some(media) = msg.media() {

--- a/lib/grammers-client/examples/reconnection.rs
+++ b/lib/grammers-client/examples/reconnection.rs
@@ -43,13 +43,14 @@ async fn async_main() -> Result {
     /// happy listening to updates forever!!
     use grammers_client::Update;
 
-    client.update_stream()
+    client
+        .update_stream()
         .try_for_each_concurrent(None, |update| async {
             match update {
                 Update::NewMessage(message) if !message.outgoing() => {
                     message.respond(message.text()).await.map(|_| ())
                 }
-                _ => Ok(())
+                _ => Ok(()),
             }
         })
         .await?;

--- a/lib/grammers-client/examples/reconnection.rs
+++ b/lib/grammers-client/examples/reconnection.rs
@@ -1,5 +1,6 @@
 //! this example demonstrate how to implement custom Reconnection Polies
 
+use futures::TryStreamExt;
 use grammers_client::session::Session;
 use grammers_client::{Client, Config, InitParams, ReconnectionPolicy};
 use std::ops::ControlFlow;
@@ -42,16 +43,18 @@ async fn async_main() -> Result {
     /// happy listening to updates forever!!
     use grammers_client::Update;
 
-    loop {
-        let update = client.next_update().await?;
-
-        match update {
-            Update::NewMessage(message) if !message.outgoing() => {
-                message.respond(message.text()).await?;
+    client.update_stream()
+        .try_for_each_concurrent(None, |update| async {
+            match update {
+                Update::NewMessage(message) if !message.outgoing() => {
+                    message.respond(message.text()).await.map(|_| ())
+                }
+                _ => Ok(())
             }
-            _ => {}
-        }
-    }
+        })
+        .await?;
+
+    Ok(())
 }
 
 fn main() -> Result {

--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -201,7 +201,10 @@ impl ParticipantStream {
 impl Stream for ParticipantStream {
     type Item = Result<Participant, InvocationError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         // Need to split the `match` because `fill_buffer()` borrows mutably.
         match self.deref_mut() {
             Self::Empty => {}
@@ -221,7 +224,7 @@ impl Stream for ParticipantStream {
                         Err(e) => return Poll::Ready(Some(Err(e))),
                     }
                 }
-                
+
                 let this = self.fill_buffer();
                 futures::pin_mut!(this);
                 if let Err(e) = futures::ready!(this.poll(cx)) {
@@ -324,7 +327,10 @@ impl ProfilePhotoStream {
 impl Stream for ProfilePhotoStream {
     type Item = Result<Photo, InvocationError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         // Need to split the `match` because `fill_buffer()` borrows mutably.
         match self.deref_mut() {
             Self::User(iter) => {
@@ -334,7 +340,7 @@ impl Stream for ProfilePhotoStream {
                         Err(e) => return Poll::Ready(Some(Err(e))),
                     }
                 }
-                
+
                 let this = self.fill_buffer();
                 futures::pin_mut!(this);
                 if let Err(e) = futures::ready!(this.poll(cx)) {
@@ -342,14 +348,17 @@ impl Stream for ProfilePhotoStream {
                 }
             }
             Self::Chat(ref mut iter) => {
-                while let Some(maybe_message) =  futures::ready!(Pin::new(&mut *iter).poll_next(cx)) {
+                while let Some(maybe_message) = futures::ready!(Pin::new(&mut *iter).poll_next(cx))
+                {
                     match maybe_message {
-                        Ok(message) => if let Some(tl::enums::MessageAction::ChatEditPhoto(
-                            tl::types::MessageActionChatEditPhoto { photo },
-                        )) = message.raw_action
-                        {
-                            return Poll::Ready(Some(Ok(Photo::from_raw(photo))));
-                        },
+                        Ok(message) => {
+                            if let Some(tl::enums::MessageAction::ChatEditPhoto(
+                                tl::types::MessageActionChatEditPhoto { photo },
+                            )) = message.raw_action
+                            {
+                                return Poll::Ready(Some(Ok(Photo::from_raw(photo))));
+                            }
+                        }
                         Err(e) => return Poll::Ready(Some(Err(e))),
                     }
                 }

--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -293,8 +293,7 @@ impl ProfilePhotoIter {
                     iter.request.offset += photos.len() as i32;
                 }
 
-                iter.buffer
-                    .extend(photos.into_iter().map(|x| Photo::from_raw(x)));
+                iter.buffer.extend(photos.into_iter().map(Photo::from_raw));
 
                 Ok(total)
             }

--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -655,7 +655,7 @@ impl Client {
     /// ```
     /// # use futures::TryStreamExt;
     /// # async fn f(chat: grammers_client::types::Chat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut photos = client.iter_profile_photos(&chat);
+    /// let mut photos = client.stream_profile_photos(&chat);
     ///
     /// while let Some(photo) = photos.try_next().await? {
     ///     println!("Did you know chat has a photo with ID {}?", photo.id());

--- a/lib/grammers-client/src/client/dialogs.rs
+++ b/lib/grammers-client/src/client/dialogs.rs
@@ -5,18 +5,24 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use crate::types::{ChatMap, Dialog, IterBuffer, Message};
-use crate::Client;
+use std::collections::HashMap;
+use std::future::Future;
+use std::task::Poll;
+
+use futures::Stream;
+
 use grammers_mtsender::InvocationError;
 use grammers_session::PackedChat;
 use grammers_tl_types as tl;
-use std::collections::HashMap;
+
+use crate::types::{ChatMap, Dialog, IterBuffer, Message};
+use crate::Client;
 
 const MAX_LIMIT: usize = 100;
 
-pub type DialogIter = IterBuffer<tl::functions::messages::GetDialogs, Dialog>;
+pub type DialogStream = IterBuffer<tl::functions::messages::GetDialogs, Dialog>;
 
-impl DialogIter {
+impl DialogStream {
     fn new(client: &Client) -> Self {
         // TODO let users tweak all the options from the request
         Self::from_request(
@@ -53,20 +59,33 @@ impl DialogIter {
         self.total = Some(total);
         Ok(total)
     }
+}
 
-    /// Return the next `Dialog` from the internal buffer, filling the buffer previously if it's
-    /// empty.
-    ///
-    /// Returns `None` if the `limit` is reached or there are no dialogs left.
-    pub async fn next(&mut self) -> Result<Option<Dialog>, InvocationError> {
+impl Stream for DialogStream {
+    type Item = Result<Dialog, InvocationError>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
-            return result;
+            match result {
+                Ok(Some(d)) => return Poll::Ready(Some(Ok(d))),
+                Err(e) => return Poll::Ready(Some(Err(e))),
+                _ => (),
+            }
         }
 
         use tl::enums::messages::Dialogs;
 
-        self.request.limit = self.determine_limit(MAX_LIMIT);
-        let (dialogs, messages, users, chats) = match self.client.invoke(&self.request).await? {
+        let result = {
+            self.request.limit = self.determine_limit(MAX_LIMIT);
+            let this = self.client.invoke(&self.request);
+            futures::pin_mut!(this);
+            futures::ready!(this.poll(cx))
+        }?;
+
+        let (dialogs, messages, users, chats) = match result {
             Dialogs::Dialogs(d) => {
                 self.last_chunk = true;
                 self.total = Some(d.dialogs.len());
@@ -96,33 +115,41 @@ impl DialogIter {
             .collect::<HashMap<_, _>>();
 
         {
-            let mut state = self.client.0.state.write().unwrap();
-            self.buffer.extend(dialogs.into_iter().map(|dialog| {
-                if let tl::enums::Dialog::Dialog(tl::types::Dialog {
-                    peer: tl::enums::Peer::Channel(channel),
-                    pts: Some(pts),
-                    ..
-                }) = &dialog
-                {
-                    state
-                        .message_box
-                        .try_set_channel_state(channel.channel_id, *pts);
+            {
+                let mut state = self.client.0.state.write().unwrap();
+                for dialog in dialogs.iter() {
+                    if let tl::enums::Dialog::Dialog(tl::types::Dialog {
+                        peer: tl::enums::Peer::Channel(channel),
+                        pts: Some(pts),
+                        ..
+                    }) = dialog
+                    {
+                        state
+                            .message_box
+                            .try_set_channel_state(channel.channel_id, *pts);
+                    }
                 }
-                Dialog::new(dialog, &mut messages, &chats)
-            }));
+            }
+
+            self.buffer.extend(
+                dialogs
+                    .into_iter()
+                    .map(|dialog| Dialog::new(dialog, &mut messages, &chats)),
+            );
         }
 
         // Don't bother updating offsets if this is the last time stuff has to be fetched.
         if !self.last_chunk && !self.buffer.is_empty() {
             self.request.exclude_pinned = true;
-            if let Some(last_message) = self
+            if let Some((date, id)) = self
                 .buffer
                 .iter()
                 .rev()
                 .find_map(|dialog| dialog.last_message.as_ref())
+                .map(|lm| (lm.raw.date, lm.raw.id))
             {
-                self.request.offset_date = last_message.raw.date;
-                self.request.offset_id = last_message.raw.id;
+                self.request.offset_date = date;
+                self.request.offset_id = id;
             }
             self.request.offset_peer = self.buffer[self.buffer.len() - 1]
                 .chat()
@@ -130,7 +157,7 @@ impl DialogIter {
                 .to_input_peer();
         }
 
-        Ok(self.pop_item())
+        Poll::Ready(self.pop_item().map(Ok))
     }
 }
 
@@ -155,8 +182,8 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn iter_dialogs(&self) -> DialogIter {
-        DialogIter::new(self)
+    pub fn stream_dialogs(&self) -> DialogStream {
+        DialogStream::new(self)
     }
 
     /// Deletes a dialog, effectively removing it from your list of open conversations.

--- a/lib/grammers-client/src/client/dialogs.rs
+++ b/lib/grammers-client/src/client/dialogs.rs
@@ -164,7 +164,7 @@ impl Stream for DialogStream {
             Some(total) => {
                 let rem = total - self.fetched;
                 (rem, Some(rem))
-            },
+            }
             None => (0, None),
         }
     }

--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -128,8 +128,7 @@ impl Stream for DownloadStream {
             return Poll::Ready(None);
         }
 
-        if let Some(data) = &self.photo_size_data {
-            let data = data.clone();
+        if let Some(data) = self.photo_size_data.take() {
             self.done = true;
             return Poll::Ready(Some(Ok(data)));
         }
@@ -178,16 +177,17 @@ impl Stream for DownloadStream {
 
 /// Method implementations related to uploading or downloading files.
 impl Client {
-    /// Returns a new iterator over the contents of a media document that will be downloaded.
+    /// Returns a new stream over the contents of a media document that will be downloaded.
     ///
     /// # Examples
     ///
     /// ```
+    /// # use futures::TryStreamExt;
     /// # async fn f(downloadable: grammers_client::types::Downloadable, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// let mut file_bytes = Vec::new();
-    /// let mut download = client.iter_download(&downloadable);
+    /// let mut download = client.stream_download(&downloadable);
     ///
-    /// while let Some(chunk) = download.next().await? {
+    /// while let Some(chunk) = download.try_next().await? {
     ///     file_bytes.extend(chunk);
     /// }
     ///
@@ -203,7 +203,7 @@ impl Client {
     ///
     /// If the file already exists, it will be overwritten.
     ///
-    /// This is a small wrapper around [`Client::iter_download`] for the common case of
+    /// This is a small wrapper around [`Client::stream_download`] for the common case of
     /// wanting to save the file locally.
     ///
     /// # Examples

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -235,7 +235,10 @@ impl MessageStream {
 impl Stream for MessageStream {
     type Item = Result<Message, InvocationError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
             match result {
                 Ok(m) => return Poll::Ready(m.map(Ok)),
@@ -373,7 +376,10 @@ impl SearchStream {
 impl Stream for SearchStream {
     type Item = Result<Message, InvocationError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
             match result {
                 Ok(m) => return Poll::Ready(m.map(Ok)),
@@ -459,7 +465,10 @@ impl GlobalSearchStream {
 impl Stream for GlobalSearchStream {
     type Item = Result<Message, InvocationError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
             match result {
                 Ok(m) => return Poll::Ready(m.map(Ok)),

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -193,9 +193,9 @@ impl<R: tl::RemoteCall<Return = tl::enums::messages::Messages>> IterBuffer<R, Me
     }
 }
 
-pub type MessageIter = IterBuffer<tl::functions::messages::GetHistory, Message>;
+pub type MessageStream = IterBuffer<tl::functions::messages::GetHistory, Message>;
 
-impl MessageIter {
+impl MessageStream {
     fn new(client: &Client, peer: PackedChat) -> Self {
         Self::from_request(
             client,
@@ -230,27 +230,41 @@ impl MessageIter {
         self.request.limit = 1;
         self.get_total().await
     }
+}
 
-    /// Return the next `Message` from the internal buffer, filling the buffer previously if it's
-    /// empty.
-    ///
-    /// Returns `None` if the `limit` is reached or there are no messages left.
-    pub async fn next(&mut self) -> Result<Option<Message>, InvocationError> {
+impl Stream for MessageStream {
+    type Item = Result<Message, InvocationError>;
+
+    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
-            return result;
+            match result {
+                Ok(m) => return Poll::Ready(m.map(Ok)),
+                Err(e) => return Poll::Ready(Some(Err(e))),
+            }
         }
 
-        self.request.limit = self.determine_limit(MAX_LIMIT);
-        self.fill_buffer(self.request.limit).await?;
+        {
+            self.request.limit = self.determine_limit(MAX_LIMIT);
+            let limit = self.request.limit;
+            let this = self.fill_buffer(limit);
+            futures::pin_mut!(this);
+            if let Err(e) = futures::ready!(this.poll(cx)) {
+                return Poll::Ready(Some(Err(e)));
+            }
+        }
 
         // Don't bother updating offsets if this is the last time stuff has to be fetched.
         if !self.last_chunk && !self.buffer.is_empty() {
-            let last = &self.buffer[self.buffer.len() - 1];
-            self.request.offset_id = last.raw.id;
-            self.request.offset_date = last.raw.date;
+            let (offset_id, offset_date) = {
+                let last = &self.buffer[self.buffer.len() - 1];
+                (last.raw.id, last.raw.date)
+            };
+
+            self.request.offset_id = offset_id;
+            self.request.offset_date = offset_date;
         }
 
-        Ok(self.pop_item())
+        Poll::Ready(self.pop_item().map(Ok))
     }
 }
 
@@ -391,9 +405,9 @@ impl Stream for SearchStream {
     }
 }
 
-pub type GlobalSearchIter = IterBuffer<tl::functions::messages::SearchGlobal, Message>;
+pub type GlobalSearchStream = IterBuffer<tl::functions::messages::SearchGlobal, Message>;
 
-impl GlobalSearchIter {
+impl GlobalSearchStream {
     fn new(client: &Client) -> Self {
         // TODO let users tweak all the options from the request
         Self::from_request(
@@ -440,28 +454,42 @@ impl GlobalSearchIter {
         self.request.limit = 1;
         self.get_total().await
     }
+}
 
-    /// Return the next `Message` from the internal buffer, filling the buffer previously if it's
-    /// empty.
-    ///
-    /// Returns `None` if the `limit` is reached or there are no messages left.
-    pub async fn next(&mut self) -> Result<Option<Message>, InvocationError> {
+impl Stream for GlobalSearchStream {
+    type Item = Result<Message, InvocationError>;
+
+    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
-            return result;
+            match result {
+                Ok(m) => return Poll::Ready(m.map(Ok)),
+                Err(e) => return Poll::Ready(Some(Err(e))),
+            }
         }
 
-        self.request.limit = self.determine_limit(MAX_LIMIT);
-        let offset_rate = self.fill_buffer(self.request.limit).await?;
+        let offset_rate = {
+            self.request.limit = self.determine_limit(MAX_LIMIT);
+            let limit = self.request.limit;
+            let this = self.fill_buffer(limit);
+            futures::pin_mut!(this);
+            match futures::ready!(this.poll(cx)) {
+                Ok(offset_rate) => offset_rate,
+                Err(e) => return Poll::Ready(Some(Err(e))),
+            }
+        };
 
         // Don't bother updating offsets if this is the last time stuff has to be fetched.
         if !self.last_chunk && !self.buffer.is_empty() {
-            let last = &self.buffer[self.buffer.len() - 1];
             self.request.offset_rate = offset_rate.unwrap_or(0);
-            self.request.offset_peer = last.chat().pack().to_input_peer();
-            self.request.offset_id = last.raw.id;
+            let (offset_peer, offset_id) = {
+                let last = &self.buffer[self.buffer.len() - 1];
+                (last.chat().pack().to_input_peer(), last.raw.id)
+            };
+            self.request.offset_peer = offset_peer;
+            self.request.offset_id = offset_id;
         }
 
-        Ok(self.pop_item())
+        Poll::Ready(self.pop_item().map(Ok))
     }
 }
 
@@ -926,23 +954,24 @@ impl Client {
             .filter(|m| !filter_req || m.raw.peer_id == message.raw.peer_id))
     }
 
-    /// Iterate over the message history of a chat, from most recent to oldest.
+    /// Get a stream over the message history of a chat, from most recent to oldest.
     ///
     /// # Examples
     ///
     /// ```
+    /// # use futures::TryStreamExt;
     /// # async fn f(chat: grammers_client::types::Chat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// // Note we're setting a reasonable limit, or we'd print out ALL the messages in chat!
     /// let mut messages = client.iter_messages(&chat).limit(100);
     ///
-    /// while let Some(message) = messages.next().await? {
+    /// while let Some(message) = messages.try_next().await? {
     ///     println!("{}", message.text());
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub fn iter_messages<C: Into<PackedChat>>(&self, chat: C) -> MessageIter {
-        MessageIter::new(self, chat.into())
+    pub fn stream_messages<C: Into<PackedChat>>(&self, chat: C) -> MessageStream {
+        MessageStream::new(self, chat.into())
     }
 
     /// Get a stream over the messages that match certain search criteria.
@@ -968,7 +997,7 @@ impl Client {
         SearchStream::new(self, chat.into())
     }
 
-    /// Iterate over the messages that match certain search criteria, without being restricted to
+    /// Get a stream over the messages that match certain search criteria, without being restricted to
     /// searching in a specific chat. The downside is that this global search supports less filters.
     ///
     /// This allows you to search by text within a chat or filter by media among other things.
@@ -976,18 +1005,19 @@ impl Client {
     /// # Examples
     ///
     /// ```
+    /// # use futures::TryStreamExt;
     /// # async fn f(client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// // Let's print all the chats were people think grammers is cool.
     /// let mut messages = client.search_all_messages().query("grammers is cool");
     ///
-    /// while let Some(message) = messages.next().await? {
+    /// while let Some(message) = messages.try_next().await? {
     ///     println!("{}", message.chat().name().unwrap_or(&message.chat().id().to_string()));
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub fn search_all_messages(&self) -> GlobalSearchIter {
-        GlobalSearchIter::new(self)
+    pub fn search_all_messages(&self) -> GlobalSearchStream {
+        GlobalSearchStream::new(self)
     }
 
     /// Get up to 100 messages using their ID.

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -12,11 +12,14 @@ use crate::types::{InputReactions, IterBuffer, Message};
 use crate::utils::{generate_random_id, generate_random_ids};
 use crate::{types, ChatMap, Client, InputMedia};
 use chrono::{DateTime, FixedOffset};
+use futures::Stream;
 pub use grammers_mtsender::{AuthorizationError, InvocationError};
 use grammers_session::PackedChat;
 use grammers_tl_types as tl;
 use log::{log_enabled, warn, Level};
 use std::collections::HashMap;
+use std::future::Future;
+use std::task::Poll;
 use tl::enums::InputPeer;
 
 fn map_random_ids_to_messages(
@@ -251,9 +254,9 @@ impl MessageIter {
     }
 }
 
-pub type SearchIter = IterBuffer<tl::functions::messages::Search, Message>;
+pub type SearchStream = IterBuffer<tl::functions::messages::Search, Message>;
 
-impl SearchIter {
+impl SearchStream {
     fn new(client: &Client, peer: PackedChat) -> Self {
         // TODO let users tweak all the options from the request
         Self::from_request(
@@ -351,27 +354,40 @@ impl SearchIter {
         self.request.limit = 0;
         self.get_total().await
     }
+}
 
-    /// Return the next `Message` from the internal buffer, filling the buffer previously if it's
-    /// empty.
-    ///
-    /// Returns `None` if the `limit` is reached or there are no messages left.
-    pub async fn next(&mut self) -> Result<Option<Message>, InvocationError> {
+impl Stream for SearchStream {
+    type Item = Result<Message, InvocationError>;
+
+    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(result) = self.next_raw() {
-            return result;
+            match result {
+                Ok(m) => return Poll::Ready(m.map(Ok)),
+                Err(e) => return Poll::Ready(Some(Err(e))),
+            }
         }
 
-        self.request.limit = self.determine_limit(MAX_LIMIT);
-        self.fill_buffer(self.request.limit).await?;
+        {
+            self.request.limit = self.determine_limit(MAX_LIMIT);
+            let limit = self.request.limit;
+            let this = self.fill_buffer(limit);
+            futures::pin_mut!(this);
+            if let Err(e) = futures::ready!(this.poll(cx)) {
+                return Poll::Ready(Some(Err(e)));
+            }
+        }
 
         // Don't bother updating offsets if this is the last time stuff has to be fetched.
         if !self.last_chunk && !self.buffer.is_empty() {
-            let last = &self.buffer[self.buffer.len() - 1];
-            self.request.offset_id = last.raw.id;
-            self.request.max_date = last.raw.date;
+            let (last_id, last_date) = {
+                let last = &self.buffer[self.buffer.len() - 1];
+                (last.raw.id, last.raw.date)
+            };
+            self.request.offset_id = last_id;
+            self.request.max_date = last_date;
         }
 
-        Ok(self.pop_item())
+        Poll::Ready(self.pop_item().map(Ok))
     }
 }
 
@@ -929,26 +945,27 @@ impl Client {
         MessageIter::new(self, chat.into())
     }
 
-    /// Iterate over the messages that match certain search criteria.
+    /// Get a stream over the messages that match certain search criteria.
     ///
     /// This allows you to search by text within a chat or filter by media among other things.
     ///
     /// # Examples
     ///
     /// ```
+    /// # use futures::TryStreamExt;
     /// # async fn f(chat: grammers_client::types::Chat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// // Let's print all the people who think grammers is cool.
     /// let mut messages = client.search_messages(&chat).query("grammers is cool");
     ///
-    /// while let Some(message) = messages.next().await? {
+    /// while let Some(message) = messages.try_next().await? {
     ///     let sender = message.sender().unwrap();
     ///     println!("{}", sender.name().unwrap_or(&sender.id().to_string()));
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub fn search_messages<C: Into<PackedChat>>(&self, chat: C) -> SearchIter {
-        SearchIter::new(self, chat.into())
+    pub fn search_messages<C: Into<PackedChat>>(&self, chat: C) -> SearchStream {
+        SearchStream::new(self, chat.into())
     }
 
     /// Iterate over the messages that match certain search criteria, without being restricted to

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -971,7 +971,7 @@ impl Client {
     /// # use futures::TryStreamExt;
     /// # async fn f(chat: grammers_client::types::Chat, client: grammers_client::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// // Note we're setting a reasonable limit, or we'd print out ALL the messages in chat!
-    /// let mut messages = client.iter_messages(&chat).limit(100);
+    /// let mut messages = client.stream_messages(&chat).limit(100);
     ///
     /// while let Some(message) = messages.try_next().await? {
     ///     println!("{}", message.text());

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -49,7 +49,7 @@ impl Client {
         loop {
             let (update, chats) = self.next_raw_update().await?;
 
-            if let Some(update) = Update::new(&self, update, &chats) {
+            if let Some(update) = Update::new(self, update, &chats) {
                 return Ok(update);
             }
         }

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -180,7 +180,8 @@ impl<'a> UpdateStream<'a> {
                         .message_box
                         .apply_difference(response, &mut state.chat_hashes)
                 };
-                self.client.extend_update_queue(updates, ChatMap::new(users, chats));
+                self.client
+                    .extend_update_queue(updates, ChatMap::new(users, chats));
                 continue;
             }
 
@@ -203,7 +204,8 @@ impl<'a> UpdateStream<'a> {
                         // Instead we manually extract the previously-known pts and use that.
                         log::warn!("Getting difference for channel updates caused PersistentTimestampOutdated; ending getting difference prematurely until server issues are resolved");
                         {
-                            self.client.0
+                            self.client
+                                .0
                                 .state
                                 .write()
                                 .unwrap()
@@ -223,7 +225,8 @@ impl<'a> UpdateStream<'a> {
                                 .unwrap_or_else(|| "empty channel".into())
                         );
                         {
-                            self.client.0
+                            self.client
+                                .0
                                 .state
                                 .write()
                                 .unwrap()
@@ -235,7 +238,8 @@ impl<'a> UpdateStream<'a> {
                     Err(InvocationError::Rpc(rpc_error)) if rpc_error.code == 500 => {
                         log::warn!("Telegram is having internal issues: {:#?}", rpc_error);
                         {
-                            self.client.0
+                            self.client
+                                .0
                                 .state
                                 .write()
                                 .unwrap()
@@ -259,7 +263,8 @@ impl<'a> UpdateStream<'a> {
                     )
                 };
 
-                self.client.extend_update_queue(updates, ChatMap::new(users, chats));
+                self.client
+                    .extend_update_queue(updates, ChatMap::new(users, chats));
                 continue;
             }
 
@@ -272,13 +277,15 @@ impl<'a> UpdateStream<'a> {
             }
         }
     }
-
 }
 
 impl<'a> Stream for UpdateStream<'a> {
     type Item = Result<Update, InvocationError>;
 
-    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         loop {
             let (update, chats) = {
                 let this = self.next_raw_update();
@@ -317,7 +324,7 @@ mod tests {
     #[test]
     fn ensure_next_update_future_impls_send() {
         use futures::TryStreamExt;
-        
+
         if false {
             // We just want it to type-check, not actually run.
             fn typeck(_: impl Future + Send) {}

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -270,7 +270,7 @@ impl User {
     /// If the current user is a bot, does it have [privacy mode] enabled?
     ///
     /// * Bots with privacy enabled won't see messages in groups unless they are replied or the
-    /// command includes their name (`/command@bot`).
+    ///   command includes their name (`/command@bot`).
     /// * Bots with privacy disabled will be able to see all messages in a group.
     ///
     /// [privacy mode]: https://core.telegram.org/bots#privacy-mode

--- a/lib/grammers-client/src/types/inline/query.rs
+++ b/lib/grammers-client/src/types/inline/query.rs
@@ -53,7 +53,7 @@ impl InlineQuery {
         }
     }
 
-    ///	User that sent the query
+    /// User that sent the query
     pub fn sender(&self) -> &User {
         match self
             .chats

--- a/lib/grammers-client/src/types/message.rs
+++ b/lib/grammers-client/src/types/message.rs
@@ -379,7 +379,7 @@ impl Message {
     /// This not only includes photos or videos, but also contacts, polls, documents, locations
     /// and many other types.
     pub fn media(&self) -> Option<types::Media> {
-        self.raw.media.clone().and_then(|x| Media::from_raw(x))
+        self.raw.media.clone().and_then(Media::from_raw)
     }
 
     /// If the message has a reply markup (which can happen for messages produced by bots),

--- a/lib/grammers-client/src/types/reactions.rs
+++ b/lib/grammers-client/src/types/reactions.rs
@@ -9,7 +9,7 @@
 use grammers_tl_types as tl;
 use tl::enums::Reaction;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct InputReactions {
     pub(crate) reactions: Vec<Reaction>,
     pub(crate) add_to_recent: bool,
@@ -58,25 +58,15 @@ impl InputReactions {
     }
 }
 
-impl Default for InputReactions {
-    fn default() -> Self {
-        Self {
-            reactions: vec![],
-            add_to_recent: false,
-            big: false,
-        }
+impl From<String> for InputReactions {
+    fn from(val: String) -> Self {
+        InputReactions::emoticon(val)
     }
 }
 
-impl Into<InputReactions> for String {
-    fn into(self) -> InputReactions {
-        InputReactions::emoticon(self)
-    }
-}
-
-impl Into<InputReactions> for &str {
-    fn into(self) -> InputReactions {
-        InputReactions::emoticon(self)
+impl From<&str> for InputReactions {
+    fn from(val: &str) -> Self {
+        InputReactions::emoticon(val)
     }
 }
 
@@ -89,8 +79,8 @@ impl From<Vec<Reaction>> for InputReactions {
     }
 }
 
-impl Into<Vec<Reaction>> for InputReactions {
-    fn into(self) -> Vec<Reaction> {
-        self.reactions
+impl From<InputReactions> for Vec<Reaction> {
+    fn from(val: InputReactions) -> Self {
+        val.reactions
     }
 }

--- a/lib/grammers-mtsender/src/errors.rs
+++ b/lib/grammers-mtsender/src/errors.rs
@@ -24,7 +24,7 @@ impl Clone for ReadError {
         match self {
             Self::Io(e) => Self::Io(
                 e.raw_os_error()
-                    .map(|raw| io::Error::from_raw_os_error(raw))
+                    .map(io::Error::from_raw_os_error)
                     .unwrap_or_else(|| io::Error::new(e.kind(), e.to_string())),
             ),
             Self::Transport(e) => Self::Transport(e.clone()),


### PR DESCRIPTION
In this PR I plan to rewrite all `iter_*` methods to use [`futures::Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) instead of manual iterator implementation.
Using [`futures::Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) could give us some very good advantages, for example there are tons of useful traits in `futures` that we can then use with our `Stream`'s and its also overall a more standard way then what we are doing right now.

# Todo:

* [x] `iter_download` => `stream_download`
* [x] `iter_dialogs` => `stream_dialogs`
* [x] `iter_participants` => `stream_participants`
* [x] `iter_profile_photos` => `stream_profile_photos`
* [x] `iter_messages` => `stream_messages`
* [x] `search_messages` => `search_messages`
* [ ] `search_all_messages` => `search_all_messages`
* [ ] Improve the overall code

# Questions:
1. should we really change the name of methods to `stream_*`? or is there better names
2. should we re-export `futures` crate?
3. using `pin_mut` macro everywhere doesn't seems like a good idea, what else should we do? should we implement custom future for lower level types?