### PR TITLE
[WASM-1] Implement the obfuscated MTProto transport

### DIFF
--- a/lib/grammers-crypto/Cargo.toml
+++ b/lib/grammers-crypto/Cargo.toml
@@ -23,6 +23,7 @@ pbkdf2 = "0.12.2"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 num-traits = "0.2.19"
+ctr = "0.9.2"
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/lib/grammers-crypto/DEPS.md
+++ b/lib/grammers-crypto/DEPS.md
@@ -48,3 +48,7 @@ Used for methods relied on by the 2-factor offered by Telegram.
 ## toml
 
 Used to test that this file lists all dependencies from `Cargo.toml`.
+
+## ctr
+
+Used for the AES-CTR mode needed for the obfuscated MTProto transport.

--- a/lib/grammers-crypto/src/lib.rs
+++ b/lib/grammers-crypto/src/lib.rs
@@ -13,6 +13,7 @@ mod auth_key;
 pub mod deque_buffer;
 pub mod factorize;
 pub mod hex;
+pub mod obfuscated;
 pub mod rsa;
 pub mod sha;
 pub mod two_factor_auth;

--- a/lib/grammers-crypto/src/obfuscated.rs
+++ b/lib/grammers-crypto/src/obfuscated.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use aes::cipher::{generic_array::GenericArray, KeyIvInit, StreamCipher};
+
+/// This implements the AES-256-CTR cipher used by Telegram to encrypt data
+/// when using the obfuscated transport.
+///
+/// You're not supposed to use this directly, You're probably looking for the
+/// actual implementation in `grammers-mtproto`.
+pub struct ObfuscatedCipher {
+    rx: ctr::Ctr128BE<aes::Aes256>,
+    tx: ctr::Ctr128BE<aes::Aes256>,
+}
+
+impl ObfuscatedCipher {
+    pub fn new(init: &[u8; 64]) -> Self {
+        let init_rev = init.iter().copied().rev().collect::<Vec<_>>();
+        Self {
+            rx: ctr::Ctr128BE::<aes::Aes256>::new(
+                GenericArray::from_slice(&init_rev[8..40]),
+                GenericArray::from_slice(&init_rev[40..56]),
+            ),
+            tx: ctr::Ctr128BE::<aes::Aes256>::new(
+                GenericArray::from_slice(&init[8..40]),
+                GenericArray::from_slice(&init[40..56]),
+            ),
+        }
+    }
+
+    pub fn encrypt(&mut self, buffer: &mut [u8]) {
+        self.tx.apply_keystream(buffer);
+    }
+
+    pub fn decrypt(&mut self, buffer: &mut [u8]) {
+        self.rx.apply_keystream(buffer);
+    }
+}

--- a/lib/grammers-mtproto/src/transport/abridged.rs
+++ b/lib/grammers-mtproto/src/transport/abridged.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use super::{Error, Transport, UnpackedOffset};
+use super::{Error, Tagged, Transport, UnpackedOffset};
 use grammers_crypto::DequeBuffer;
 
 /// The lightest MTProto transport protocol available. This is an
@@ -109,6 +109,13 @@ impl Transport for Abridged {
     fn reset(&mut self) {
         log::info!("resetting sending of header in abridged transport");
         self.init = false;
+    }
+}
+
+impl Tagged for Abridged {
+    fn init_tag(&mut self) -> [u8; 4] {
+        self.init = true;
+        [0xef, 0xef, 0xef, 0xef]
     }
 }
 

--- a/lib/grammers-mtproto/src/transport/abridged.rs
+++ b/lib/grammers-mtproto/src/transport/abridged.rs
@@ -63,7 +63,7 @@ impl Transport for Abridged {
         }
     }
 
-    fn unpack(&mut self, buffer: &[u8]) -> Result<UnpackedOffset, Error> {
+    fn unpack(&mut self, buffer: &mut [u8]) -> Result<UnpackedOffset, Error> {
         if buffer.is_empty() {
             return Err(Error::MissingBytes);
         }
@@ -160,7 +160,7 @@ mod tests {
         let mut transport = Abridged::new();
         let mut buffer = DequeBuffer::with_capacity(1, 0);
         buffer.extend([1]);
-        assert_eq!(transport.unpack(&buffer[..]), Err(Error::MissingBytes));
+        assert_eq!(transport.unpack(&mut buffer[..]), Err(Error::MissingBytes));
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
         let orig = buffer.clone();
         transport.pack(&mut buffer);
         let n = 1; // init byte
-        let offset = transport.unpack(&buffer[n..][..]).unwrap();
+        let offset = transport.unpack(&mut buffer[n..][..]).unwrap();
         assert_eq!(&buffer[n..][offset.data_start..offset.data_end], &orig[..]);
     }
 
@@ -187,12 +187,12 @@ mod tests {
         transport.pack(&mut buffer);
         two_buffer.extend(&buffer[..]);
 
-        let offset = transport.unpack(&two_buffer[..]).unwrap();
+        let offset = transport.unpack(&mut two_buffer[..]).unwrap();
         assert_eq!(&buffer[offset.data_start..offset.data_end], &orig[..]);
         assert_eq!(offset.next_offset, single_size);
 
         let n = offset.next_offset;
-        let offset = transport.unpack(&two_buffer[n..]).unwrap();
+        let offset = transport.unpack(&mut two_buffer[n..]).unwrap();
         assert_eq!(&buffer[offset.data_start..offset.data_end], &orig[..]);
     }
 
@@ -202,7 +202,7 @@ mod tests {
         let orig = buffer.clone();
         transport.pack(&mut buffer);
         let n = 1; // init byte
-        let offset = transport.unpack(&buffer[n..]).unwrap();
+        let offset = transport.unpack(&mut buffer[n..]).unwrap();
         assert_eq!(&buffer[n..][offset.data_start..offset.data_end], &orig[..]);
     }
 
@@ -214,7 +214,7 @@ mod tests {
         buffer.extend(&(-404_i32).to_le_bytes());
 
         assert_eq!(
-            transport.unpack(&buffer[..]),
+            transport.unpack(&mut buffer[..]),
             Err(Error::BadStatus { status: 404 })
         );
     }

--- a/lib/grammers-mtproto/src/transport/mod.rs
+++ b/lib/grammers-mtproto/src/transport/mod.rs
@@ -91,7 +91,7 @@ pub trait Transport {
     fn pack(&mut self, buffer: &mut DequeBuffer<u8>);
 
     /// Unpacks the input buffer in-place.
-    fn unpack(&mut self, buffer: &[u8]) -> Result<UnpackedOffset, Error>;
+    fn unpack(&mut self, buffer: &mut [u8]) -> Result<UnpackedOffset, Error>;
 
     /// Reset the state, as if a new instance was just created.
     fn reset(&mut self);

--- a/lib/grammers-mtproto/src/transport/mod.rs
+++ b/lib/grammers-mtproto/src/transport/mod.rs
@@ -14,11 +14,13 @@
 mod abridged;
 mod full;
 mod intermediate;
+mod obfuscated;
 
 pub use abridged::Abridged;
 pub use full::Full;
 use grammers_crypto::DequeBuffer;
 pub use intermediate::Intermediate;
+pub use obfuscated::Obfuscated;
 use std::fmt;
 
 /// The error type reported by the different transports when something is wrong.
@@ -91,8 +93,17 @@ pub trait Transport {
     fn pack(&mut self, buffer: &mut DequeBuffer<u8>);
 
     /// Unpacks the input buffer in-place.
+    /// Subsequent calls to `unpack` should be made with the same buffer,
+    /// with the data on the ranges from previous `UnpackedOffset` removed.
     fn unpack(&mut self, buffer: &mut [u8]) -> Result<UnpackedOffset, Error>;
 
     /// Reset the state, as if a new instance was just created.
     fn reset(&mut self);
+}
+
+/// The trait used by the obfuscated transport to get the transport tags.
+pub trait Tagged {
+    /// Gets the transport tag for use in the obfuscated transport and
+    /// changes the internal state to avoid sending the tag again.
+    fn init_tag(&mut self) -> [u8; 4];
 }

--- a/lib/grammers-mtproto/src/transport/obfuscated.rs
+++ b/lib/grammers-mtproto/src/transport/obfuscated.rs
@@ -1,0 +1,111 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use grammers_crypto::{obfuscated::ObfuscatedCipher, DequeBuffer};
+use log::debug;
+
+use super::{Error, Tagged, Transport, UnpackedOffset};
+
+/// An obfuscation protocol made by telegram to avoid ISP blocks.
+/// This is needed to connect to the Telegram servers using websockets or
+/// when conecting to MTProto proxies (not yet supported).
+///
+/// It is simply a wrapper around another transport, which encrypts the data
+/// using AES-256-CTR with a randomly generated key that is then sent at the
+/// beginning of the connection.
+///
+/// Obfuscated transport can only be used with "tagged" transports, which
+/// provide a way to get the obfuscated tag that is used in the encryption.
+/// See the linked documentation for more information.
+///
+/// [Transport Obfuscation](https://core.telegram.org/mtproto/mtproto-transports#transport-obfuscation)
+pub struct Obfuscated<T: Transport + Tagged> {
+    inner: T,
+    head: Option<[u8; 64]>,
+    decrypt_tail: usize,
+    cipher: ObfuscatedCipher,
+}
+
+const FORBIDDEN_FIRST_INTS: [[u8; 4]; 7] = [
+    [b'H', b'E', b'A', b'D'], // HTTP HEAD
+    [b'P', b'O', b'S', b'T'], // HTTP POST
+    [b'G', b'E', b'T', b' '], // HTTP GET
+    [b'O', b'P', b'T', b'I'], // HTTP OPTIONS
+    [0x16, 0x03, 0x01, 0x02], // TLS handshake
+    [0xdd, 0xdd, 0xdd, 0xdd], // Padded Intermediate
+    [0xee, 0xee, 0xee, 0xee], // Intermediate
+];
+
+impl<T: Transport + Tagged> Obfuscated<T> {
+    fn generate_keys(inner: &mut T) -> ([u8; 64], ObfuscatedCipher) {
+        let mut init = [0; 64];
+
+        while init[4..8] == [0; 4] // Full
+            || init[0] == 0xef // Abridged
+            || FORBIDDEN_FIRST_INTS.iter().any(|start| start == &init[..4])
+        {
+            getrandom::getrandom(&mut init).unwrap();
+        }
+
+        init[56..60].copy_from_slice(&inner.init_tag());
+
+        let mut cipher = ObfuscatedCipher::new(&init);
+
+        let mut encrypted_init = init.to_vec();
+        cipher.encrypt(&mut encrypted_init);
+        init[56..64].copy_from_slice(&encrypted_init[56..64]);
+
+        (init, cipher)
+    }
+
+    pub fn new(mut inner: T) -> Self {
+        let (init, cipher) = Self::generate_keys(&mut inner);
+
+        Self {
+            inner,
+            head: Some(init),
+            decrypt_tail: 0,
+            cipher,
+        }
+    }
+}
+
+impl<T: Transport + Tagged> Transport for Obfuscated<T> {
+    fn pack(&mut self, buffer: &mut DequeBuffer<u8>) {
+        self.inner.pack(buffer);
+        self.cipher.encrypt(buffer.as_mut());
+        if let Some(head) = self.head.take() {
+            buffer.extend_front(&head);
+        }
+    }
+
+    fn unpack(&mut self, buffer: &mut [u8]) -> Result<UnpackedOffset, Error> {
+        if buffer.len() < self.decrypt_tail {
+            panic!("buffer is smaller than what was decrypted");
+        }
+
+        self.cipher.decrypt(&mut buffer[self.decrypt_tail..]);
+        self.decrypt_tail = buffer.len();
+
+        match self.inner.unpack(buffer) {
+            Ok(offset) => {
+                self.decrypt_tail -= offset.next_offset;
+                Ok(offset)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        debug!("regenerating keys for obfuscated transport");
+
+        let (init, cipher) = Self::generate_keys(&mut self.inner);
+        self.head = Some(init);
+        self.cipher = cipher;
+    }
+}

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -476,7 +476,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
         while next_offset != self.read_tail {
             match self
                 .transport
-                .unpack(&self.read_buffer[next_offset..self.read_tail])
+                .unpack(&mut self.read_buffer[next_offset..self.read_tail])
             {
                 Ok(offset) => {
                     debug!("deserializing valid transport packet...");


### PR DESCRIPTION
This PR implements support for [transport obfuscation](https://core.telegram.org/mtproto/mtproto-transports#transport-obfuscation). It is the first step towards a web port.

## Changes I had to make to make this feasible:
- `Transport::unpack()` now takes in a mutable reference to the buffer to do the decryption in-place.
- ~`Transport::unpack()` now returns `Result<Vec<UnpackedOffset>>`. This is needed since a read might, and frequently will, contain multiple transport payloads.~
- ~`Transport::unpack()` now returns an empty Vec instead of `Error::MissingBytes` when there's more data needed.~
- `ctr` is a new dependency in `grammers-mtsender`.
- `Transport::unpack()` must now be called with the same buffer and the buffer must be kept between calls.

~While changing the return type of unpack to a `Vec` doesn't also seem good, it was the only compromise I could think of to allow this transport to work without significant performance impact while also keeping the decryption contained inside of the transport implementation.~

I'm now storing the decryption state inside the transport itself. So should have almost zero overhead other than the encryption itself
