### PR TITLE
[WASM-2] Put code using fs APIs under their own feature

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -19,6 +19,8 @@ html = ["html5ever"]
 proxy = ["grammers-mtsender/proxy"]
 parse_invite_link = ["url"]
 serde = ["grammers-tl-types/impl-serde"]
+fs = ["tokio/fs"]
+default = ["fs"]
 
 [dependencies]
 chrono = "0.4.38"
@@ -39,7 +41,6 @@ os_info = { version = "3.8.2", default-features = false }
 pin-project-lite = "0.2"
 pulldown-cmark = { version = "0.12.1", default-features = false, optional = true }
 tokio = { version = "1.40.0", default-features = false, features = [
-    "fs",
     "rt",
 ] }
 url = { version = "2.5.2", optional = true }

--- a/lib/grammers-client/src/types/message.rs
+++ b/lib/grammers-client/src/types/message.rs
@@ -8,7 +8,7 @@
 #[cfg(any(feature = "markdown", feature = "html"))]
 use crate::parsers;
 use crate::types::reactions::InputReactions;
-use crate::types::{Downloadable, InputMessage, Media, Photo};
+use crate::types::{InputMessage, Media, Photo};
 use crate::ChatMap;
 use crate::{types, Client};
 use crate::{utils, InputMedia};
@@ -17,10 +17,14 @@ use grammers_mtsender::InvocationError;
 use grammers_session::PackedChat;
 use grammers_tl_types as tl;
 use std::fmt;
-use std::io;
-use std::path::Path;
 use std::sync::Arc;
 use types::Chat;
+
+#[cfg(feature = "fs")]
+use {
+    crate::types::Downloadable,
+    std::{io, path::Path},
+};
 
 pub(crate) const EMPTY_MESSAGE: tl::types::Message = tl::types::Message {
     out: false,
@@ -674,6 +678,7 @@ impl Message {
     /// Returns `true` if there was media to download, or `false` otherwise.
     ///
     /// Shorthand for `Client::download_media`.
+    #[cfg(feature = "fs")]
     pub async fn download_media<P: AsRef<Path>>(&self, path: P) -> Result<bool, io::Error> {
         // TODO probably encode failed download in error
         if let Some(media) = self.media() {


### PR DESCRIPTION
The title is pretty self-explanatory.

This is needed for when we add wasm support as fs is not supported there.
It also has the added bonus of allowing people to guarantee that the crate does not create any files without the feature. 