### PR TITLE
[WASM-3] Time suff

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1.40.0", default-features = false, features = [
     "rt",
 ] }
 url = { version = "2.5.2", optional = true }
+web-time = "1.1.0"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", default-features = false, features = [

--- a/lib/grammers-client/DEPS.md
+++ b/lib/grammers-client/DEPS.md
@@ -83,3 +83,8 @@ Provides Stream functionality
 ## url
 
 Used to parse certain URLs to offer features such as joining private chats via their invite link.
+
+## web-time
+
+Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
+Automatically falls back to `std::time` when we're not targeting web.

--- a/lib/grammers-client/src/client/client.rs
+++ b/lib/grammers-client/src/client/client.rs
@@ -15,8 +15,8 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
 use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use web_time::Instant;
 
 /// When no locale is found, use this one instead.
 const DEFAULT_LOCALE: &str = "en";

--- a/lib/grammers-client/src/client/net.rs
+++ b/lib/grammers-client/src/client/net.rs
@@ -10,7 +10,9 @@ use super::{Client, ClientInner, Config};
 use crate::utils;
 use grammers_mtproto::mtp;
 use grammers_mtproto::transport;
-use grammers_mtsender::{self as sender, AuthorizationError, InvocationError, RpcError, Sender};
+use grammers_mtsender::{
+    self as sender, utils::sleep, AuthorizationError, InvocationError, RpcError, Sender,
+};
 use grammers_session::{ChatHashCache, MessageBox};
 use grammers_tl_types::{self as tl, Deserializable};
 use log::{debug, info};
@@ -397,7 +399,7 @@ impl Connection {
                             delay,
                             std::any::type_name::<R>()
                         );
-                        tokio::time::sleep(delay).await;
+                        sleep(delay).await;
                         slept_flood = true;
                         rx = self.request_tx.read().unwrap().enqueue(request);
                         continue;

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -17,8 +17,9 @@ pub use grammers_session::{PrematureEndReason, UpdateState};
 use grammers_tl_types as tl;
 use std::pin::pin;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::time::sleep_until;
+use std::time::Duration;
+use web_time::Instant;
 
 /// How long to wait after warning the user that the updates limit was exceeded.
 const UPDATE_LIMIT_EXCEEDED_LOG_COOLDOWN: Duration = Duration::from_secs(300);

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -281,6 +281,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     fn ensure_next_update_future_impls_send() {
         if false {
             // We just want it to type-check, not actually run.

--- a/lib/grammers-client/src/client/updates.rs
+++ b/lib/grammers-client/src/client/updates.rs
@@ -11,13 +11,13 @@
 use super::Client;
 use crate::types::{ChatMap, Update};
 use futures::future::{select, Either};
+use grammers_mtsender::utils::sleep_until;
 pub use grammers_mtsender::{AuthorizationError, InvocationError};
 use grammers_session::channel_id;
 pub use grammers_session::{PrematureEndReason, UpdateState};
 use grammers_tl_types as tl;
 use std::pin::pin;
 use std::sync::Arc;
-use tokio::time::sleep_until;
 use std::time::Duration;
 use web_time::Instant;
 

--- a/lib/grammers-client/src/types/action.rs
+++ b/lib/grammers-client/src/types/action.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use futures::future::Either;
+use grammers_mtsender::utils;
 use grammers_mtsender::InvocationError;
 use grammers_session::PackedChat;
 use grammers_tl_types as tl;
@@ -118,7 +119,7 @@ impl ActionSender {
 
             let action = async {
                 request_result = self.oneshot(action().into()).await;
-                tokio::time::sleep(self.repeat_delay).await;
+                utils::sleep(self.repeat_delay).await;
             };
 
             tokio::pin!(action);

--- a/lib/grammers-client/src/types/chats.rs
+++ b/lib/grammers-client/src/types/chats.rs
@@ -12,11 +12,12 @@ use std::{
     mem::drop,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
 use futures::TryStreamExt;
 use pin_project_lite::pin_project;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use grammers_mtsender::{InvocationError, RpcError};
 use grammers_session::PackedChat;

--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -8,7 +8,7 @@
 use super::attributes::Attribute;
 use crate::types::{Media, ReplyMarkup, Uploaded};
 use grammers_tl_types as tl;
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 // https://github.com/telegramdesktop/tdesktop/blob/e7fbcce9d9f0a8944eb2c34e74bd01b8776cb891/Telegram/SourceFiles/data/data_scheduled_messages.h#L52
 const SCHEDULE_ONCE_ONLINE: i32 = 0x7ffffffe;

--- a/lib/grammers-client/src/utils.rs
+++ b/lib/grammers-client/src/utils.rs
@@ -12,7 +12,7 @@ use grammers_session::{PackedChat, PackedType};
 use grammers_tl_types as tl;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::thread;
-use std::time::SystemTime;
+use web_time::SystemTime;
 
 // This atomic isn't for anything critical, just to generate unique IDs without locks.
 // The worst that can happen if the load and store orderings are wrong is that the IDs

--- a/lib/grammers-mtproto/Cargo.toml
+++ b/lib/grammers-mtproto/Cargo.toml
@@ -23,6 +23,7 @@ grammers-tl-types = { path = "../grammers-tl-types", version = "0.7.0", features
 log = "0.4.22"
 num-bigint = "0.4.6"
 sha1 = "0.10.6"
+web-time = "1.1.0"
 
 [dev-dependencies]
 toml = "0.8.19"

--- a/lib/grammers-mtproto/DEPS.md
+++ b/lib/grammers-mtproto/DEPS.md
@@ -41,3 +41,8 @@ Used to test that this file lists all dependencies from `Cargo.toml`.
 ## log
 
 Used to help debug what's going on at the MTP level (such as when future salts are asked for).
+
+## web-time
+
+Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
+Automatically falls back to `std::time` when we're not targeting web.

--- a/lib/grammers-mtproto/src/authentication.rs
+++ b/lib/grammers-mtproto/src/authentication.rs
@@ -39,7 +39,7 @@ use grammers_tl_types::{self as tl, Cursor, Deserializable, RemoteCall, Serializ
 use num_bigint::{BigUint, ToBigUint};
 use sha1::{Digest, Sha1};
 use std::fmt;
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 // NOTE! Turning this on will leak the key generation process to stdout!
 // Should only be used for debugging purposes and generating test cases.

--- a/lib/grammers-mtproto/src/mtp/encrypted.rs
+++ b/lib/grammers-mtproto/src/mtp/encrypted.rs
@@ -15,7 +15,7 @@ use grammers_crypto::{decrypt_data_v2, encrypt_data_v2, AuthKey, DequeBuffer};
 use grammers_tl_types::{self as tl, Cursor, Deserializable, Identifiable, Serializable};
 use log::info;
 use std::mem;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// How many future salts to fetch or have stored at a given time.
 ///

--- a/lib/grammers-mtsender/Cargo.toml
+++ b/lib/grammers-mtsender/Cargo.toml
@@ -31,6 +31,10 @@ hickory-resolver = { version = "0.24.1", optional = true }
 url = { version = "2.5.2", optional = true }
 web-time = "1.1.0"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen-futures = "0.4.49"
+web-sys = {version = "0.3.76", features = ["Window"]}
+
 [dev-dependencies]
 simple_logger = { version = "5.0.0", default-features = false, features = ["colors"] }
 tokio = { version = "1.40.0", features = ["rt"] }

--- a/lib/grammers-mtsender/Cargo.toml
+++ b/lib/grammers-mtsender/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.40.0", default-features = false, features = ["net", "io-u
 tokio-socks = { version = "0.5.2", optional = true }
 hickory-resolver = { version = "0.24.1", optional = true }
 url = { version = "2.5.2", optional = true }
+web-time = "1.1.0"
 
 [dev-dependencies]
 simple_logger = { version = "5.0.0", default-features = false, features = ["colors"] }

--- a/lib/grammers-mtsender/DEPS.md
+++ b/lib/grammers-mtsender/DEPS.md
@@ -54,3 +54,13 @@ SOCKS5 proxy support.
 
 Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
 Automatically falls back to `std::time` when we're not targeting web.
+
+## web-sys
+
+Only used when targeting `wasm32-unknown-unknown`. Used by the `Timeout` implementation to
+call `setTimeout` and `clearTimeout` in the browser.
+
+## wasm-bindgen-futures
+
+Only used when targeting `wasm32-unknown-unknown`. Used by the `Timeout` implementation to
+convert a `Promise` into a `Future`.

--- a/lib/grammers-mtsender/DEPS.md
+++ b/lib/grammers-mtsender/DEPS.md
@@ -49,3 +49,8 @@ Provides useful functions for working with futures/tasks.
 ## tokio-socks
 
 SOCKS5 proxy support.
+
+## web-time
+
+Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
+Automatically falls back to `std::time` when we're not targeting web.

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod errors;
 mod reconnection;
+pub mod utils;
 
 pub use crate::reconnection::*;
 pub use errors::{AuthorizationError, InvocationError, ReadError, RpcError};
@@ -35,7 +36,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
-use tokio::time::sleep_until;
+use utils::{sleep, sleep_until};
 use web_time::{Instant, SystemTime};
 
 #[cfg(feature = "proxy")]
@@ -387,7 +388,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                 Err(e) => {
                     attempts += 1;
                     log::warn!("auto-reconnect failed {} time(s): {}", attempts, e);
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    sleep(Duration::from_secs(1)).await;
 
                     match self.reconnection_policy.should_retry(attempts) {
                         ControlFlow::Break(_) => {
@@ -398,7 +399,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                             return Err(e);
                         }
                         ControlFlow::Continue(duration) => {
-                            tokio::time::sleep(duration).await;
+                            sleep(duration).await;
                         }
                     }
                 }

--- a/lib/grammers-mtsender/src/lib.rs
+++ b/lib/grammers-mtsender/src/lib.rs
@@ -27,7 +27,7 @@ use std::io::Error;
 use std::ops::ControlFlow;
 use std::pin::pin;
 use std::sync::atomic::{AtomicI64, Ordering};
-use std::time::SystemTime;
+use std::time::Duration;
 use tl::Serializable;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{ReadHalf, WriteHalf};
@@ -35,7 +35,8 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
-use tokio::time::{sleep_until, Duration, Instant};
+use tokio::time::sleep_until;
+use web_time::{Instant, SystemTime};
 
 #[cfg(feature = "proxy")]
 use {

--- a/lib/grammers-mtsender/src/utils.rs
+++ b/lib/grammers-mtsender/src/utils.rs
@@ -1,0 +1,93 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::time::Duration;
+use web_time::Instant;
+
+/// A cancellable timeout for web platforms.
+/// It is simply a wrapper around `window.setTimeout` but also makes
+/// sure to clear the timeout when dropped to avoid leaking timers.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub struct Timeout {
+    handle: std::cell::OnceCell<i32>,
+    inner: wasm_bindgen_futures::JsFuture,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl std::future::Future for Timeout {
+    type Output = ();
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        std::pin::Pin::new(&mut self.get_mut().inner)
+            .poll(cx)
+            .map(|_| ())
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl Drop for Timeout {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.get() {
+            web_sys::window()
+                .unwrap()
+                .clear_timeout_with_handle(*handle);
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl Timeout {
+    pub fn new(duration: Duration) -> Self {
+        use wasm_bindgen_futures::js_sys;
+
+        let handle = std::cell::OnceCell::new();
+        let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
+            handle
+                .set(
+                    web_sys::window()
+                        .unwrap()
+                        .set_timeout_with_callback_and_timeout_and_arguments_0(
+                            &resolve,
+                            duration.as_millis() as i32,
+                        )
+                        .unwrap(),
+                )
+                .expect("timeout already set");
+        };
+
+        let inner = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut cb));
+        Self { handle, inner }
+    }
+}
+
+/// a web-friendly version of `tokio::time::sleep`
+pub async fn sleep(duration: Duration) {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        return tokio::time::sleep(duration).await;
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        Timeout::new(duration).await;
+    }
+}
+
+/// a web-friendly version of `tokio::time::sleep_until`
+pub async fn sleep_until(deadline: Instant) {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        return tokio::time::sleep_until(deadline.into()).await;
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        Timeout::new(deadline - Instant::now()).await;
+    }
+}

--- a/lib/grammers-session/Cargo.toml
+++ b/lib/grammers-session/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2021"
 grammers-tl-types = { path = "../grammers-tl-types", version = "0.7.0" }
 grammers-crypto = { path = "../grammers-crypto", version = "0.7.0" }
 log = "0.4.22"
+web-time = "1.1.0"
 
 [build-dependencies]
 grammers-tl-gen = { path = "../grammers-tl-gen", version = "0.7.0" }

--- a/lib/grammers-session/DEPS.md
+++ b/lib/grammers-session/DEPS.md
@@ -27,3 +27,8 @@ Used to log messages during update processing.
 ## toml
 
 Used to test that this file lists all dependencies from `Cargo.toml`.
+
+## web-time
+
+Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
+Automatically falls back to `std::time` when we're not targeting web.

--- a/lib/grammers-session/src/message_box/defs.rs
+++ b/lib/grammers-session/src/message_box/defs.rs
@@ -7,7 +7,8 @@
 // except according to those terms.
 use grammers_tl_types as tl;
 use std::collections::{HashMap, HashSet};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 /// Telegram sends `seq` equal to `0` when "it doesn't matter", so we use that value too.
 pub(super) const NO_SEQ: i32 = 0;

--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -38,8 +38,9 @@ use log::{debug, info, trace, warn};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::mem;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tl::enums::InputChannel;
+use web_time::Instant;
 
 fn next_updates_deadline() -> Instant {
     Instant::now() + defs::NO_UPDATES_TIMEOUT


### PR DESCRIPTION
### Changes:
- Replace usages of `tokio::time` and `std::time` with `web-time` 
- Change the `deps` test add the ability to scan target-specific dependencies
- Disable the test that checks if client is `Send` when targeting web as JS objects are not thread-safe (there's no "thread" to begin with)
- Implement `sleep` and `sleep_until` using js `setTimeout()`