### PR TITLE
[WASM-4] Clean up mtsender, ws support and small changes to make it usable

### DIFF
--- a/lib/grammers-client/src/client/client.rs
+++ b/lib/grammers-client/src/client/client.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use grammers_mtproto::{mtp, transport};
+use grammers_mtproto::mtp;
 use grammers_mtsender::{self as sender, ReconnectionPolicy, Sender, ServerAddr};
 use grammers_session::{ChatHashCache, MessageBox, Session};
 use grammers_tl_types as tl;
@@ -16,6 +16,8 @@ use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use web_time::Instant;
+
+use super::net;
 
 /// When no locale is found, use this one instead.
 const DEFAULT_LOCALE: &str = "en";
@@ -138,7 +140,7 @@ pub(crate) struct ClientState {
 }
 
 pub(crate) struct Connection {
-    pub(crate) sender: AsyncMutex<Sender<transport::Full, mtp::Encrypted>>,
+    pub(crate) sender: AsyncMutex<Sender<net::Transport, mtp::Encrypted>>,
     pub(crate) request_tx: RwLock<Enqueuer>,
     pub(crate) step_counter: AtomicU32,
 }

--- a/lib/grammers-client/src/client/client.rs
+++ b/lib/grammers-client/src/client/client.rs
@@ -6,13 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use grammers_mtproto::{mtp, transport};
-use grammers_mtsender::{self as sender, ReconnectionPolicy, Sender};
+use grammers_mtsender::{self as sender, ReconnectionPolicy, Sender, ServerAddr};
 use grammers_session::{ChatHashCache, MessageBox, Session};
 use grammers_tl_types as tl;
 use sender::Enqueuer;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::net::SocketAddr;
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
@@ -60,7 +59,7 @@ pub struct InitParams {
     /// in the session file (or a default production address if no such address exists). This
     /// field can be used to override said address, and is most commonly used to connect to one
     /// of Telegram's test servers instead.
-    pub server_addr: Option<SocketAddr>,
+    pub server_addr: Option<ServerAddr>,
     /// The threshold below which the library should automatically sleep on flood-wait and slow
     /// mode wait errors (inclusive). For instance, if an
     /// `RpcError { name: "FLOOD_WAIT", value: Some(17) }` (flood, must wait 17 seconds) occurs

--- a/lib/grammers-client/src/lib.rs
+++ b/lib/grammers-client/src/lib.rs
@@ -49,6 +49,9 @@ pub mod parsers;
 pub mod types;
 pub(crate) mod utils;
 
+#[cfg(all(feature = "fs", target_arch = "wasm32", target_os = "unknown"))]
+compile_error!("The `fs` feature is not supported on wasm32-unknown-unknown.");
+
 pub use client::{Client, Config, InitParams, SignInError};
 pub use types::{button, reply_markup, ChatMap, InputMedia, InputMessage, Update};
 

--- a/lib/grammers-crypto/Cargo.toml
+++ b/lib/grammers-crypto/Cargo.toml
@@ -25,6 +25,9 @@ sha2 = "0.10.8"
 num-traits = "0.2.19"
 ctr = "0.9.2"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2.15", features = ["js"] }
+
 [dev-dependencies]
 bencher = "0.1.5"
 toml = "0.8.19"

--- a/lib/grammers-mtproto/Cargo.toml
+++ b/lib/grammers-mtproto/Cargo.toml
@@ -25,5 +25,8 @@ num-bigint = "0.4.6"
 sha1 = "0.10.6"
 web-time = "1.1.0"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2.15", features = ["js"] }
+
 [dev-dependencies]
 toml = "0.8.19"

--- a/lib/grammers-mtsender/Cargo.toml
+++ b/lib/grammers-mtsender/Cargo.toml
@@ -25,15 +25,20 @@ grammers-crypto = { path = "../grammers-crypto", version = "0.7.0" }
 grammers-mtproto = { path = "../grammers-mtproto", version = "0.7.0" }
 grammers-tl-types = { path = "../grammers-tl-types", version = "0.7.0", features = [ "tl-mtproto" ] }
 log = "0.4.22"
-tokio = { version = "1.40.0", default-features = false, features = ["net", "io-util", "sync", "time"] }
+tokio = { version = "1.40.0", default-features = false, features = ["io-util", "sync", "time"] }
 tokio-socks = { version = "0.5.2", optional = true }
 hickory-resolver = { version = "0.24.1", optional = true }
 url = { version = "2.5.2", optional = true }
 web-time = "1.1.0"
 
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
+tokio = { version = "1.40.0", default-features = false, features = ["net"] }
+
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.49"
 web-sys = {version = "0.3.76", features = ["Window"]}
+ws_stream_wasm = { version = "0.7.4", features = ["tokio_io"] }
+async_io_stream = { version = "0.3.3", features = ["tokio_io"] }
 
 [dev-dependencies]
 simple_logger = { version = "5.0.0", default-features = false, features = ["colors"] }

--- a/lib/grammers-mtsender/DEPS.md
+++ b/lib/grammers-mtsender/DEPS.md
@@ -64,3 +64,13 @@ call `setTimeout` and `clearTimeout` in the browser.
 
 Only used when targeting `wasm32-unknown-unknown`. Used by the `Timeout` implementation to
 convert a `Promise` into a `Future`.
+
+## ws_stream_wasm
+
+Only used when targeting `wasm32-unknown-unknown`. Used to create a WebSocket connection
+and get a byte stream from it.
+
+## async_io_stream
+
+Only used when targeting `wasm32-unknown-unknown`. Used to create a tokio-compatible stream
+from a WebSocket connection.

--- a/lib/grammers-mtsender/src/net/mod.rs
+++ b/lib/grammers-mtsender/src/net/mod.rs
@@ -6,18 +6,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 mod tcp;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod ws;
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use tcp::NetStream;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub use ws::NetStream;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "proxy"))]
+compile_error!("TCP proxies are not supported when compiling for WASM");
 
 #[derive(Debug, Clone)]
 pub enum ServerAddr {
-    #[cfg(feature = "proxy")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    Ws { address: String },
+    #[cfg(all(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        feature = "proxy"
+    ))]
     Proxied {
         address: std::net::SocketAddr,
         proxy: String,
     },
-    Tcp {
-        address: std::net::SocketAddr,
-    },
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    Tcp { address: std::net::SocketAddr },
 }

--- a/lib/grammers-mtsender/src/net/mod.rs
+++ b/lib/grammers-mtsender/src/net/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod tcp;
+
+pub use tcp::NetStream;
+
+#[derive(Debug, Clone)]
+pub enum ServerAddr {
+    #[cfg(feature = "proxy")]
+    Proxied {
+        address: std::net::SocketAddr,
+        proxy: String,
+    },
+    Tcp {
+        address: std::net::SocketAddr,
+    },
+}

--- a/lib/grammers-mtsender/src/net/tcp.rs
+++ b/lib/grammers-mtsender/src/net/tcp.rs
@@ -1,0 +1,109 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use log::info;
+pub use tokio::net::tcp::{ReadHalf, WriteHalf};
+use tokio::net::TcpStream;
+
+use super::ServerAddr;
+
+pub enum NetStream {
+    Tcp(TcpStream),
+    #[cfg(feature = "proxy")]
+    ProxySocks5(tokio_socks::tcp::Socks5Stream<TcpStream>),
+}
+
+impl NetStream {
+    pub(crate) fn split(&mut self) -> (ReadHalf, WriteHalf) {
+        match self {
+            Self::Tcp(stream) => stream.split(),
+            #[cfg(feature = "proxy")]
+            Self::ProxySocks5(stream) => stream.split(),
+        }
+    }
+
+    pub(crate) async fn connect(addr: &ServerAddr) -> Result<Self, std::io::Error> {
+        info!("connecting...");
+        match addr {
+            ServerAddr::Tcp { address } => Ok(NetStream::Tcp(TcpStream::connect(address).await?)),
+            #[cfg(feature = "proxy")]
+            ServerAddr::Proxied { address, proxy } => {
+                Self::connect_proxy_stream(address, proxy).await
+            }
+        }
+    }
+
+    #[cfg(feature = "proxy")]
+    async fn connect_proxy_stream(
+        addr: &std::net::SocketAddr,
+        proxy_url: &str,
+    ) -> Result<NetStream, std::io::Error> {
+        use std::{
+            io::{self, ErrorKind},
+            net::{IpAddr, SocketAddr},
+        };
+
+        use hickory_resolver::{
+            config::{ResolverConfig, ResolverOpts},
+            AsyncResolver,
+        };
+        use url::Host;
+
+        let proxy = url::Url::parse(proxy_url)
+            .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))?;
+        let scheme = proxy.scheme();
+        let host = proxy.host().ok_or(io::Error::new(
+            ErrorKind::NotFound,
+            format!("proxy host is missing from url: {}", proxy_url),
+        ))?;
+        let port = proxy.port().ok_or(io::Error::new(
+            ErrorKind::NotFound,
+            format!("proxy port is missing from url: {}", proxy_url),
+        ))?;
+        let username = proxy.username();
+        let password = proxy.password().unwrap_or("");
+        let socks_addr = match host {
+            Host::Domain(domain) => {
+                let resolver =
+                    AsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+                let response = resolver.lookup_ip(domain).await?;
+                let socks_ip_addr = response.into_iter().next().ok_or(io::Error::new(
+                    ErrorKind::NotFound,
+                    format!("proxy host did not return any ip address: {}", domain),
+                ))?;
+                SocketAddr::new(socks_ip_addr, port)
+            }
+            Host::Ipv4(v4) => SocketAddr::new(IpAddr::from(v4), port),
+            Host::Ipv6(v6) => SocketAddr::new(IpAddr::from(v6), port),
+        };
+
+        match scheme {
+            "socks5" => {
+                if username.is_empty() {
+                    Ok(NetStream::ProxySocks5(
+                        tokio_socks::tcp::Socks5Stream::connect(socks_addr, addr)
+                            .await
+                            .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))?,
+                    ))
+                } else {
+                    Ok(NetStream::ProxySocks5(
+                        tokio_socks::tcp::Socks5Stream::connect_with_password(
+                            socks_addr, addr, username, password,
+                        )
+                        .await
+                        .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))?,
+                    ))
+                }
+            }
+            scheme => Err(io::Error::new(
+                ErrorKind::ConnectionAborted,
+                format!("proxy scheme not supported: {}", scheme),
+            )),
+        }
+    }
+}

--- a/lib/grammers-mtsender/src/net/ws.rs
+++ b/lib/grammers-mtsender/src/net/ws.rs
@@ -1,0 +1,42 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use futures_util::TryFutureExt;
+use log::info;
+
+use super::ServerAddr;
+
+type WsIo = async_io_stream::IoStream<ws_stream_wasm::WsStreamIo, Vec<u8>>;
+pub type ReadHalf<'a> = tokio::io::ReadHalf<&'a mut WsIo>;
+pub type WriteHalf<'a> = tokio::io::WriteHalf<&'a mut WsIo>;
+
+pub struct NetStream(WsIo);
+
+impl NetStream {
+    pub(crate) fn split(&mut self) -> (ReadHalf, WriteHalf) {
+        tokio::io::split(&mut self.0)
+    }
+
+    pub(crate) async fn connect(addr: &ServerAddr) -> Result<Self, std::io::Error> {
+        info!("connecting...");
+        match addr {
+            ServerAddr::Ws { address } => {
+                let (_, wsio) = ws_stream_wasm::WsMeta::connect(address, Some(["binary"].to_vec()))
+                    .map_err(|err| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            format!("failed to connect to websocket: {}", err),
+                        )
+                    })
+                    .await?;
+
+                Ok(Self(wsio.into_io()))
+            }
+        }
+    }
+}

--- a/lib/grammers-mtsender/tests/lib.rs
+++ b/lib/grammers-mtsender/tests/lib.rs
@@ -33,7 +33,9 @@ fn test_invoke_encrypted_method() {
     rt.block_on(async {
         let (mut sender, enqueuer) = connect(
             transport::Full::new(),
-            std::net::SocketAddr::from_str(TELEGRAM_TEST_DC_2).unwrap(),
+            grammers_mtsender::ServerAddr::Tcp {
+                address: std::net::SocketAddr::from_str(TELEGRAM_TEST_DC_2).unwrap(),
+            },
             &NoReconnect,
         )
         .await

--- a/lib/grammers-session/build.rs
+++ b/lib/grammers-session/build.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-const CURRENT_VERSION: i32 = 2;
+const CURRENT_VERSION: i32 = 3;
 
 fn main() -> std::io::Result<()> {
     let mut file = BufWriter::new(File::create(
@@ -23,6 +23,7 @@ fn main() -> std::io::Result<()> {
     let definitions = parse_tl_file(
         r#"
         dataCenter flags:# id:int ipv4:flags.0?int ipv6:flags.1?int128 port:int auth:flags.2?bytes = DataCenter;
+        dataCenterWs flags:# id:int url:string auth:flags.0?bytes = DataCenter;
         user id:long dc:int bot:Bool = User;
         channelState channel_id:long pts:int = ChannelState;
         updateState pts:int qts:int date:int seq:int channels:Vector<ChannelState> = UpdateState;


### PR DESCRIPTION
After this PR users should be able to use grammers in the browser! We still have a lot of testing and documenting to do but that's for another PR.

## Changes:
- Moved `NetStream` into a new mod called `net` and separate net code from the actual mtsender implementation.
- Implement WebSocket support using `ws_stream_wasm`.
- Declare a new type for the transport type in client to allow changing it using cfg.
- Use padded intermediate with obfuscation as the transport when targeting web.
- Enable the `js` feature of `getrandom` to avoid getting compile errors.
- Add a compile error when the user tries to build with the `fs` or `proxy` features but is targeting web.