### PR TITLE
allow set max_id and min_id for MessageIter and SearchIter

### DIFF
--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -220,6 +220,16 @@ impl MessageIter {
         self
     }
 
+    pub fn min_id(mut self, min_id: i32) -> Self {
+        self.request.min_id = min_id;
+        self
+    }
+
+    pub fn max_id(mut self, max_id: i32) -> Self {
+        self.request.max_id = max_id;
+        self
+    }
+
     /// Determines how many messages there are in total.
     ///
     /// This only performs a network call if `next` has not been called before.
@@ -333,6 +343,16 @@ impl SearchIter {
     /// ```
     pub fn max_date(mut self, date_time: &DateTime<FixedOffset>) -> Self {
         self.request.max_date = date_time.timestamp() as i32;
+        self
+    }
+
+    pub fn min_id(mut self, min_id: i32) -> Self {
+        self.request.min_id = min_id;
+        self
+    }
+
+    pub fn max_id(mut self, max_id: i32) -> Self {
+        self.request.max_id = max_id;
         self
     }
 


### PR DESCRIPTION
allow set max_id and min_id for MessageIter and SearchIter to filter messages like telethon.