### PR TITLE
Allow supplying custom types when answering an inline query

### DIFF
--- a/lib/grammers-client/src/types/inline/query.rs
+++ b/lib/grammers-client/src/types/inline/query.rs
@@ -82,7 +82,10 @@ impl InlineQuery {
 
     /// Answer the inline query.
     // TODO: add example
-    pub fn answer(&self, results: impl IntoIterator<Item = InlineResult>) -> Answer {
+    pub fn answer<T>(&self, results: impl IntoIterator<Item = T>) -> Answer
+    where
+        T: Into<tl::enums::InputBotInlineResult>,
+    {
         Answer {
             request: tl::functions::messages::SetInlineBotResults {
                 gallery: false,


### PR DESCRIPTION
The title is quite self-explanatory. This allows bots to actually use other inline response types using tl types instead of being restricted to only the `Article` type. 