### PR TITLE
feat(html): support collapsed attribute in blockquote tag

### DIFF
--- a/lib/grammers-client/src/parsers/html.rs
+++ b/lib/grammers-client/src/parsers/html.rs
@@ -59,11 +59,13 @@ pub fn parse_html_message(message: &str) -> (String, Vec<tl::enums::MessageEntit
                         entities.push(tl::types::MessageEntityUnderline { offset, length }.into());
                     }
                     tag!("blockquote") => {
+                        let collapsed = attrs.into_iter().any(|a| &a.name.local == "collapsed");
+
                         entities.push(
                             tl::types::MessageEntityBlockquote {
                                 offset,
                                 length,
-                                collapsed: false,
+                                collapsed,
                             }
                             .into(),
                         );

--- a/lib/grammers-client/src/parsers/html.rs
+++ b/lib/grammers-client/src/parsers/html.rs
@@ -59,7 +59,7 @@ pub fn parse_html_message(message: &str) -> (String, Vec<tl::enums::MessageEntit
                         entities.push(tl::types::MessageEntityUnderline { offset, length }.into());
                     }
                     tag!("blockquote") => {
-                        let collapsed = attrs.into_iter().any(|a| &a.name.local == "collapsed");
+                        let collapsed = attrs.into_iter().any(|a| &a.name.local == "expandable");
 
                         entities.push(
                             tl::types::MessageEntityBlockquote {

--- a/lib/grammers-client/src/parsers/html.rs
+++ b/lib/grammers-client/src/parsers/html.rs
@@ -313,7 +313,14 @@ pub fn generate_html_message(message: &str, entities: &[tl::enums::MessageEntity
                 insertions.push((after(i, 0, e.offset + e.length), Segment::Fixed("</del>")));
             }
             ME::Blockquote(e) => {
-                insertions.push((before(i, 0, e.offset), Segment::Fixed("<blockquote>")));
+                if e.collapsed {
+                    insertions.push((
+                        before(i, 0, e.offset),
+                        Segment::Fixed("<blockquote expandable>"),
+                    ));
+                } else {
+                    insertions.push((before(i, 0, e.offset), Segment::Fixed("<blockquote>")));
+                }
                 insertions.push((
                     after(i, 0, e.offset + e.length),
                     Segment::Fixed("</blockquote>"),


### PR DESCRIPTION
With this, now we can use:
```rust
InputMessage::html("<blockquote expandable>Lorem ip...</blockquote>")
```