### PR TITLE
refactored `grammers-tl-gen` to generate each of the types, functions and enums to a separate file

### DIFF
--- a/lib/grammers-session/build.rs
+++ b/lib/grammers-session/build.rs
@@ -5,19 +5,23 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use grammers_tl_gen::{generate_rust_code, Config};
+use grammers_tl_gen::{generate_rust_code, Config, Outputs};
 use grammers_tl_parser::parse_tl_file;
 use std::env;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::BufWriter;
 use std::path::Path;
 
 const CURRENT_VERSION: i32 = 3;
 
 fn main() -> std::io::Result<()> {
-    let mut file = BufWriter::new(File::create(
-        Path::new(&env::var("OUT_DIR").unwrap()).join("generated.rs"),
-    )?);
+    let output_dir = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
+    let mut outputs = Outputs {
+        common: BufWriter::new(File::create(output_dir.join("generated_common.rs"))?),
+        types: BufWriter::new(File::create(output_dir.join("generated_types.rs"))?),
+        functions: BufWriter::new(File::create(output_dir.join("generated_functions.rs"))?),
+        enums: BufWriter::new(File::create(output_dir.join("generated_enums.rs"))?),
+    };
 
     // Using boxed variants in the definitions so that deserialization fails if any constructor ID changes.
     let definitions = parse_tl_file(
@@ -37,8 +41,9 @@ fn main() -> std::io::Result<()> {
         ..Default::default()
     };
 
-    generate_rust_code(&mut file, &definitions, CURRENT_VERSION, &config)?;
-    file.flush()?;
+    generate_rust_code(&mut outputs, &definitions, CURRENT_VERSION, &config)?;
+
+    outputs.flush()?;
 
     Ok(())
 }

--- a/lib/grammers-session/src/generated/common.rs
+++ b/lib/grammers-session/src/generated/common.rs
@@ -5,4 +5,5 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+include!(concat!(env!("OUT_DIR"), "/generated_common.rs"));

--- a/lib/grammers-session/src/generated/enums.rs
+++ b/lib/grammers-session/src/generated/enums.rs
@@ -1,0 +1,18 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(clippy::large_enum_variant)]
+
+//! This module contains all of the boxed types, each
+//! represented by a `enum`. All of them implement
+//! [`Serializable`] and [`Deserializable`].
+//!
+//! [`Serializable`]: /grammers_tl_types/trait.Serializable.html
+//! [`Deserializable`]: /grammers_tl_types/trait.Deserializable.html
+
+include!(concat!(env!("OUT_DIR"), "/generated_enums.rs"));

--- a/lib/grammers-session/src/generated/mod.rs
+++ b/lib/grammers-session/src/generated/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use common::*;
+
+mod common;
+pub mod enums;
+pub mod types;

--- a/lib/grammers-session/src/generated/types.rs
+++ b/lib/grammers-session/src/generated/types.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::identity_op,
+    clippy::unreadable_literal
+)]
+
+//! This module contains all of the bare types, each
+//! represented by a `struct`. All of them implement
+//! [`Identifiable`], [`Serializable`] and [`Deserializable`].
+//!
+//! [`Identifiable`]: ../trait.Identifiable.html
+//! [`Serializable`]: ../trait.Serializable.html
+//! [`Deserializable`]: ../trait.Deserializable.html
+
+include!(concat!(env!("OUT_DIR"), "/generated_types.rs"));

--- a/lib/grammers-tl-gen/src/enums.rs
+++ b/lib/grammers-tl-gen/src/enums.rs
@@ -380,31 +380,16 @@ pub(crate) fn write_enums_mod<W: Write>(
     config: &Config,
 ) -> io::Result<()> {
     // Begin outermost mod
-    write!(
-        file,
-        "\
-         /// This module contains all of the boxed types, each\n\
-         /// represented by a `enum`. All of them implement\n\
-         /// [`Serializable`] and [`Deserializable`].\n\
-         ///\n\
-         /// [`Serializable`]: /grammers_tl_types/trait.Serializable.html\n\
-         /// [`Deserializable`]: /grammers_tl_types/trait.Deserializable.html\n\
-         #[allow(clippy::large_enum_variant)]\n\
-         pub mod enums {{\n\
-         "
-    )?;
-
     let grouped = grouper::group_types_by_ns(definitions);
     let mut sorted_keys: Vec<&Option<String>> = grouped.keys().collect();
     sorted_keys.sort();
     for key in sorted_keys.into_iter() {
         // Begin possibly inner mod
         let indent = if let Some(ns) = key {
-            writeln!(file, "    #[allow(clippy::large_enum_variant)]")?;
-            writeln!(file, "    pub mod {ns} {{")?;
-            "        "
-        } else {
+            writeln!(file, "pub mod {ns} {{")?;
             "    "
+        } else {
+            ""
         };
 
         for ty in grouped[key].iter().filter(|ty| !ignore_type(ty)) {
@@ -413,10 +398,9 @@ pub(crate) fn write_enums_mod<W: Write>(
 
         // End possibly inner mod
         if key.is_some() {
-            writeln!(file, "    }}")?;
+            writeln!(file, "}}")?;
         }
     }
 
-    // End outermost mod
-    writeln!(file, "}}")
+    Ok(())
 }

--- a/lib/grammers-tl-gen/src/lib.rs
+++ b/lib/grammers-tl-gen/src/lib.rs
@@ -20,6 +20,22 @@ mod structs;
 use grammers_tl_parser::tl::{Category, Definition, Type};
 use std::io::{self, Write};
 
+pub struct Outputs<W: Write> {
+    pub common: W,
+    pub types: W,
+    pub functions: W,
+    pub enums: W,
+}
+
+impl<W: Write> Outputs<W> {
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        self.common.flush()?;
+        self.types.flush()?;
+        self.functions.flush()?;
+        self.enums.flush()
+    }
+}
+
 pub struct Config {
     pub gen_name_for_id: bool,
     pub deserializable_functions: bool,
@@ -50,31 +66,22 @@ fn ignore_type(ty: &Type) -> bool {
     SPECIAL_CASED_TYPES.iter().any(|&x| x == ty.name)
 }
 
-pub fn generate_rust_code(
-    file: &mut impl Write,
+pub fn generate_rust_code<W: Write>(
+    outputs: &mut Outputs<W>,
     definitions: &[Definition],
     layer: i32,
     config: &Config,
 ) -> io::Result<()> {
     writeln!(
-        file,
-        r#"
-// Copyright 2020 - developers of the `grammers` project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-/// The schema layer from which the definitions were generated.
+        &mut outputs.common,
+        r#"/// The schema layer from which the definitions were generated.
 pub const LAYER: i32 = {layer};
 "#
     )?;
 
     if config.gen_name_for_id {
         writeln!(
-            file,
+            outputs.common,
             r#"
 /// Return the name from the `.tl` definition corresponding to the provided definition identifier.
 pub fn name_for_id(id: u32) -> &'static str {{
@@ -82,11 +89,16 @@ pub fn name_for_id(id: u32) -> &'static str {{
         0x1cb5c415 => "vector","#
         )?;
         for def in definitions {
-            writeln!(file, r#"        0x{:x} => "{}","#, def.id, def.full_name())?;
+            writeln!(
+                &mut outputs.common,
+                r#"        0x{:x} => "{}","#,
+                def.id,
+                def.full_name()
+            )?;
         }
 
         writeln!(
-            file,
+            outputs.common,
             r#"
         _ => "(unknown)",
     }}
@@ -96,9 +108,21 @@ pub fn name_for_id(id: u32) -> &'static str {{
     }
 
     let metadata = metadata::Metadata::new(definitions);
-    structs::write_category_mod(file, Category::Types, definitions, &metadata, config)?;
-    structs::write_category_mod(file, Category::Functions, definitions, &metadata, config)?;
-    enums::write_enums_mod(file, definitions, &metadata, config)?;
+    structs::write_category_mod(
+        &mut outputs.types,
+        Category::Types,
+        definitions,
+        &metadata,
+        config,
+    )?;
+    structs::write_category_mod(
+        &mut outputs.functions,
+        Category::Functions,
+        definitions,
+        &metadata,
+        config,
+    )?;
+    enums::write_enums_mod(&mut outputs.enums, definitions, &metadata, config)?;
 
     Ok(())
 }

--- a/lib/grammers-tl-gen/src/structs.rs
+++ b/lib/grammers-tl-gen/src/structs.rs
@@ -480,57 +480,16 @@ pub(crate) fn write_category_mod<W: Write>(
     metadata: &Metadata,
     config: &Config,
 ) -> io::Result<()> {
-    // Begin outermost mod
-    match category {
-        Category::Types => {
-            write!(
-                file,
-                "\
-                 /// This module contains all of the bare types, each\n\
-                 /// represented by a `struct`. All of them implement\n\
-                 /// [`Identifiable`], [`Serializable`] and [`Deserializable`].\n\
-                 ///\n\
-                 /// [`Identifiable`]: ../trait.Identifiable.html\n\
-                 /// [`Serializable`]: ../trait.Serializable.html\n\
-                 /// [`Deserializable`]: ../trait.Deserializable.html\n\
-                 #[allow(clippy::cognitive_complexity, clippy::identity_op, clippy::unreadable_literal)]\n\
-                 pub mod types {{\n\
-                 "
-            )?;
-        }
-        Category::Functions => {
-            writeln!(
-                file,
-                "\
-            /// This module contains all of the functions, each\n\
-            /// represented by a `struct`. All of them implement\n\
-            /// [`Identifiable`] and [`Serializable`].\n\
-            ///\n\
-            /// To find out the type that Telegram will return upon\n\
-            /// invoking one of these requests, check out the associated\n\
-            /// type in the corresponding [`RemoteCall`] trait impl.\n\
-            ///\n\
-            /// [`Identifiable`]: ../trait.Identifiable.html\n\
-            /// [`Serializable`]: ../trait.Serializable.html\n\
-            /// [`RemoteCall`]: trait.RemoteCall.html\n\
-            #[allow(clippy::cognitive_complexity, clippy::identity_op, clippy::unreadable_literal)]\n\
-            pub mod functions {{
-            "
-            )?;
-        }
-    }
-
     let grouped = grouper::group_by_ns(definitions, category);
     let mut sorted_keys: Vec<&String> = grouped.keys().collect();
     sorted_keys.sort();
     for key in sorted_keys.into_iter() {
         // Begin possibly inner mod
         let indent = if key.is_empty() {
-            "    "
+            ""
         } else {
-            writeln!(file, "    #[allow(clippy::unreadable_literal)]")?;
-            writeln!(file, "    pub mod {key} {{")?;
-            "        "
+            writeln!(file, "pub mod {key} {{")?;
+            "    "
         };
 
         if category == Category::Types && config.impl_from_enum {
@@ -549,10 +508,9 @@ pub(crate) fn write_category_mod<W: Write>(
 
         // End possibly inner mod
         if !key.is_empty() {
-            writeln!(file, "    }}")?;
+            writeln!(file, "}}")?;
         }
     }
 
-    // End outermost mod
-    writeln!(file, "}}")
+    Ok(())
 }

--- a/lib/grammers-tl-types/src/generated/common.rs
+++ b/lib/grammers-tl-types/src/generated/common.rs
@@ -5,4 +5,5 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+include!(concat!(env!("OUT_DIR"), "/generated_common.rs"));

--- a/lib/grammers-tl-types/src/generated/enums.rs
+++ b/lib/grammers-tl-types/src/generated/enums.rs
@@ -1,0 +1,18 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(clippy::large_enum_variant)]
+
+//! This module contains all of the boxed types, each
+//! represented by a `enum`. All of them implement
+//! [`Serializable`] and [`Deserializable`].
+//!
+//! [`Serializable`]: /grammers_tl_types/trait.Serializable.html
+//! [`Deserializable`]: /grammers_tl_types/trait.Deserializable.html
+
+include!(concat!(env!("OUT_DIR"), "/generated_enums.rs"));

--- a/lib/grammers-tl-types/src/generated/functions.rs
+++ b/lib/grammers-tl-types/src/generated/functions.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::identity_op,
+    clippy::unreadable_literal
+)]
+
+//! This module contains all of the functions, each
+//! represented by a `struct`. All of them implement
+//! [`Identifiable`] and [`Serializable`].
+//!
+//! To find out the type that Telegram will return upon
+//! invoking one of these requests, check out the associated
+//! type in the corresponding [`RemoteCall`] trait impl.
+//!
+//! [`Identifiable`]: ../trait.Identifiable.html
+//! [`Serializable`]: ../trait.Serializable.html
+//! [`RemoteCall`]: trait.RemoteCall.html
+
+include!(concat!(env!("OUT_DIR"), "/generated_functions.rs"));

--- a/lib/grammers-tl-types/src/generated/mod.rs
+++ b/lib/grammers-tl-types/src/generated/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use common::*;
+
+mod common;
+pub mod enums;
+pub mod functions;
+pub mod types;

--- a/lib/grammers-tl-types/src/generated/types.rs
+++ b/lib/grammers-tl-types/src/generated/types.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 - developers of the `grammers` project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::identity_op,
+    clippy::unreadable_literal
+)]
+
+//! This module contains all of the bare types, each
+//! represented by a `struct`. All of them implement
+//! [`Identifiable`], [`Serializable`] and [`Deserializable`].
+//!
+//! [`Identifiable`]: ../trait.Identifiable.html
+//! [`Serializable`]: ../trait.Serializable.html
+//! [`Deserializable`]: ../trait.Deserializable.html
+
+include!(concat!(env!("OUT_DIR"), "/generated_types.rs"));


### PR DESCRIPTION
this PR will modify the tl-gen so it generate each of types, functions and enums to a separate file, the reason I did this is, if we have all of them in a single file the resulted generated file will be so big and that will cause some problems with RA.

I did found some strange problems while doing these changes, like if we add doc comments (`//!`) to start of the generated rust source and then include that file in another file, the rust compiler will give us a error and complain that we can't use these comments here... that's why I no longer add the license and top doc comment directly to the source file when generating, instead I manually added them to the actual module that generated sources will be included in.

I also fixed the small bug after the recent `User` type changes.