### PR TITLE
Make parse_invite_link public

### DIFF
--- a/lib/grammers-client/src/client/chats.rs
+++ b/lib/grammers-client/src/client/chats.rs
@@ -757,7 +757,7 @@ impl Client {
     }
 
     #[cfg(feature = "parse_invite_link")]
-    fn parse_invite_link(invite_link: &str) -> Option<String> {
+    pub fn parse_invite_link(invite_link: &str) -> Option<String> {
         let url_parse_result = url::Url::parse(invite_link);
         if url_parse_result.is_err() {
             return None;


### PR DESCRIPTION
Currently there is no way to use the function `parse_invite_link`, which would be useful to call methods like [messages.checkChatInvite](https://core.telegram.org/method/messages.checkChatInvite).
This PR makes the function public.