### PR TITLE
fix(client): add `impl From<&mut T> for U>

### DIFF
--- a/lib/grammers-client/src/types/chat/channel.rs
+++ b/lib/grammers-client/src/types/chat/channel.rs
@@ -196,3 +196,9 @@ impl From<&Channel> for PackedChat {
         chat.pack()
     }
 }
+
+impl From<&mut Channel> for PackedChat {
+    fn from(chat: &mut Channel) -> Self {
+        chat.pack()
+    }
+}

--- a/lib/grammers-client/src/types/chat/group.rs
+++ b/lib/grammers-client/src/types/chat/group.rs
@@ -193,3 +193,9 @@ impl From<&Group> for PackedChat {
         chat.pack()
     }
 }
+
+impl From<&mut Group> for PackedChat {
+    fn from(chat: &mut Group) -> Self {
+        chat.pack()
+    }
+}

--- a/lib/grammers-client/src/types/chat/mod.rs
+++ b/lib/grammers-client/src/types/chat/mod.rs
@@ -243,3 +243,9 @@ impl From<&Chat> for PackedChat {
         chat.pack()
     }
 }
+
+impl From<&mut Chat> for PackedChat {
+    fn from(chat: &mut Chat) -> Self {
+        chat.pack()
+    }
+}

--- a/lib/grammers-client/src/types/chat/user.rs
+++ b/lib/grammers-client/src/types/chat/user.rs
@@ -352,3 +352,9 @@ impl From<&User> for PackedChat {
         chat.pack()
     }
 }
+
+impl From<&mut User> for PackedChat {
+    fn from(chat: &mut User) -> Self {
+        chat.pack()
+    }
+}

--- a/lib/grammers-client/src/types/chat_map.rs
+++ b/lib/grammers-client/src/types/chat_map.rs
@@ -30,6 +30,18 @@ impl From<&tl::enums::Peer> for Peer {
     }
 }
 
+impl From<&mut tl::enums::Peer> for Peer {
+    fn from(peer: &mut tl::enums::Peer) -> Self {
+        use tl::enums::Peer::*;
+
+        match peer {
+            User(user) => Self::User(user.user_id),
+            Chat(chat) => Self::Chat(chat.chat_id),
+            Channel(channel) => Self::Channel(channel.channel_id),
+        }
+    }
+}
+
 /// Helper structure to efficiently retrieve chats via their peer.
 ///
 /// A lot of responses include the chats related to them in the form of a list of users

--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -418,3 +418,14 @@ impl From<&super::Message> for InputMessage {
         }
     }
 }
+
+impl From<&mut super::Message> for InputMessage {
+    fn from(message: &mut super::Message) -> Self {
+        Self {
+            text: message.text().to_owned(),
+            entities: message.fmt_entities().cloned().unwrap_or(Vec::new()),
+            media: message.media().and_then(|m| m.to_raw_input_media()),
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
Add `From<&mut T> for U` to clean up api calls, so we can, for example, replace:

```rust
client.search_messages(&*chat);
```

with the cleaner:

```rust
client.search_messages(chat);
```
working with the entry api.