### PR TITLE
Fix BotInlineSend updates breaking seq

### DIFF
--- a/lib/grammers-session/src/message_box/mod.rs
+++ b/lib/grammers-session/src/message_box/mod.rs
@@ -33,8 +33,8 @@ use crate::message_box::defs::PossibleGap;
 pub(crate) use defs::Entry;
 pub use defs::{Gap, MessageBox};
 use defs::{NO_DATE, NO_PTS, NO_SEQ, POSSIBLE_GAP_TIMEOUT, PtsInfo, State};
-use grammers_tl_types::enums::Update;
 use grammers_tl_types as tl;
+use grammers_tl_types::enums::Update;
 use log::{debug, info, trace, warn};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -486,7 +486,6 @@ impl MessageBox {
         // which the deadlines should be reset, and determines whether any local pts was changed
         // so that the seq can be updated too (which could otherwise have been done earlier).
         let mut any_pts_applied = false;
-        let mut force_update_seq = false;
         let mut reset_deadlines_for = mem::take(&mut self.tmp_entries);
         for update in updates {
             let (entry, update) = self.apply_pts_info(update);
@@ -500,13 +499,8 @@ impl MessageBox {
                 // BotInlineSend updates are sent with `seq` != NO_SEQ. `seq` must be updated in
                 // that case, otherwise every other BotInlineSend update will be counted as a gap
                 // and dropped.
-                match update {
-                    Update::BotInlineSend(_) => force_update_seq = true,
-                    _ => {},
-                }
+                any_pts_applied |= entry.is_some() || matches!(update, Update::BotInlineSend(_));
                 result.push(update);
-                any_pts_applied |= entry.is_some();
-
             }
         }
         self.reset_deadlines(&reset_deadlines_for, next_updates_deadline());
@@ -520,7 +514,7 @@ impl MessageBox {
         // Updates which can be applied in any order, such as `UpdateChat`,
         // should not cause `seq` to be updated (or upcoming updates such as
         // `UpdateChatParticipant` could be missed).
-        if any_pts_applied || force_update_seq {
+        if any_pts_applied {
             if date != NO_DATE {
                 self.date = date;
             }


### PR DESCRIPTION
I noticed that my bot wasnt consistently receiving Update::InlineSend updates, so i fixed it, the comment in the code explains why this is neccesary