### PR TITLE
Don't override an existing DC, when inserting a new one

### DIFF
--- a/lib/grammers-session/src/lib.rs
+++ b/lib/grammers-session/src/lib.rs
@@ -107,12 +107,13 @@ impl Session {
             .next()
     }
 
-    fn insert_dc(&self, dc: enums::DataCenter) {
+    fn insert_dc(&self, new_dc: enums::DataCenter) {
         let mut session = self.session.lock().unwrap();
-        if let Some(pos) = session.dcs.iter().position(|dc| dc.id() == dc.id()) {
+
+        if let Some(pos) = session.dcs.iter().position(|dc| dc.id() == new_dc.id()) {
             session.dcs.remove(pos);
         }
-        session.dcs.push(dc);
+        session.dcs.push(new_dc);
     }
 
     pub fn insert_dc_tcp(&self, id: i32, addr: &SocketAddr, auth: [u8; 256]) {


### PR DESCRIPTION
- rename the parameter from `dc` to `new_dc` in the `Session::insert_dc`.  
- use the new parameter `new_dc` when checking for an existing data center with the same id, ensuring the method behaves as intended.