### PR TITLE
Export Article from inline_query

### DIFF
--- a/lib/grammers-client/src/types/update/mod.rs
+++ b/lib/grammers-client/src/types/update/mod.rs
@@ -15,6 +15,7 @@ mod raw;
 mod update;
 
 pub use callback_query::CallbackQuery;
+pub use inline_query::Article;
 pub use inline_query::InlineQuery;
 pub use inline_send::InlineSend;
 pub use message::Message;


### PR DESCRIPTION
Since the structural changes of the code, there is no way to access and use Article.
This commit exports it in mod.rs