### PR TITLE
Avoid panic in Message::peer_id() when peer_id is missing

### DIFF
--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -25,7 +25,7 @@ const SESSION_FILE: &str = "echo.session";
 async fn handle_update(client: Client, update: Update) -> Result {
     match update {
         Update::NewMessage(message) if !message.outgoing() => {
-            let chat = message.chat();
+            let chat = message.chat()?;
             println!(
                 "Responding to {}",
                 chat.name().unwrap_or(&format!("id {}", chat.id()))

--- a/lib/grammers-client/src/client/messages.rs
+++ b/lib/grammers-client/src/client/messages.rs
@@ -455,7 +455,7 @@ impl GlobalSearchIter {
         if !self.last_chunk && !self.buffer.is_empty() {
             let last = &self.buffer[self.buffer.len() - 1];
             self.request.offset_rate = offset_rate.unwrap_or(0);
-            self.request.offset_peer = last.chat().pack().to_input_peer();
+            self.request.offset_peer = last.chat()?.pack().to_input_peer();
             self.request.offset_id = last.id();
         }
 
@@ -926,7 +926,7 @@ impl Client {
         }
 
         // TODO shouldn't this method take in a message id anyway?
-        let chat = message.chat().pack();
+        let chat = message.chat()?.pack();
         let reply_to_message_id = match message.reply_to_message_id() {
             Some(id) => id,
             None => return Ok(None),
@@ -961,7 +961,9 @@ impl Client {
             .into_iter()
             .map(|m| Message::from_raw(self, m, Some(chat.to_peer()), &chats))
             .next()
-            .filter(|m| !filter_req || m.peer_id() == message.peer_id()))
+            .filter(|m| {
+                !filter_req || matches!((m.peer_id(), message.peer_id()), (Ok(a), Ok(b)) if a == b)
+            }))
     }
 
     /// Iterate over the message history of a chat, from most recent to oldest.
@@ -1018,7 +1020,7 @@ impl Client {
     /// let mut messages = client.search_all_messages().query("grammers is cool");
     ///
     /// while let Some(message) = messages.next().await? {
-    ///     println!("{}", message.chat().name().unwrap_or(&message.chat().id().to_string()));
+    ///     println!("{}", message.chat()?.name().unwrap_or(&message.chat()?.id().to_string()));
     /// }
     /// # Ok(())
     /// # }
@@ -1078,7 +1080,7 @@ impl Client {
         let mut map = messages
             .into_iter()
             .map(|m| Message::from_raw(self, m, Some(chat.to_peer()), &chats))
-            .filter(|m| m.chat().pack() == chat)
+            .filter(|m| m.chat().map(|c| c.pack() == chat).unwrap_or(false))
             .map(|m| (m.id(), m))
             .collect::<HashMap<_, _>>();
 
@@ -1130,7 +1132,7 @@ impl Client {
         Ok(messages
             .into_iter()
             .map(|m| Message::from_raw(self, m, Some(chat.to_peer()), &chats))
-            .find(|m| m.chat().pack() == chat))
+            .find(|m| m.chat().map(|c| c.pack() == chat).unwrap_or(false)))
     }
 
     /// Pin a message in the chat. This will not notify any users.

--- a/lib/grammers-client/src/types/update/callback_query.rs
+++ b/lib/grammers-client/src/types/update/callback_query.rs
@@ -103,7 +103,7 @@ impl CallbackQuery {
     }
 
     /// Answer the callback query.
-    pub fn answer(&self) -> Answer {
+    pub fn answer(&self) -> Answer<'_> {
         let query_id = match &self.raw {
             tl::enums::Update::BotCallbackQuery(update) => update.query_id,
             tl::enums::Update::InlineBotCallbackQuery(update) => update.query_id,

--- a/lib/grammers-mtsender/src/errors.rs
+++ b/lib/grammers-mtsender/src/errors.rs
@@ -177,6 +177,9 @@ pub enum InvocationError {
 
     /// The error occured while reading the response.
     Read(ReadError),
+
+    /// The update contained an empty message without a `peer_id`.
+    MissingPeerId,
 }
 
 impl std::error::Error for InvocationError {}
@@ -187,6 +190,7 @@ impl fmt::Display for InvocationError {
             Self::Rpc(err) => write!(f, "request error: {err}"),
             Self::Dropped => write!(f, "request error: dropped (cancelled)"),
             Self::Read(err) => write!(f, "request error: {err}"),
+            Self::MissingPeerId => write!(f, "request error: missing peer id"),
         }
     }
 }

--- a/lib/grammers-mtsender/src/net/tcp.rs
+++ b/lib/grammers-mtsender/src/net/tcp.rs
@@ -19,7 +19,7 @@ pub enum NetStream {
 }
 
 impl NetStream {
-    pub(crate) fn split(&mut self) -> (ReadHalf, WriteHalf) {
+    pub(crate) fn split(&mut self) -> (ReadHalf<'_>, WriteHalf<'_>) {
         match self {
             Self::Tcp(stream) => stream.split(),
             #[cfg(feature = "proxy")]


### PR DESCRIPTION
This PR changes Message::peer_id() to return Option/Result instead of unwrapping, preventing panics when processing updates with empty messages that lack a peer_id.
Added a new InvocationError::MissingPeerId to propagate this case to callers, and updated related methods (chat(), sender(), etc.) to handle the new return type.