### PR TITLE
Add serde support for session crate

### DIFF
--- a/lib/grammers-client/Cargo.toml
+++ b/lib/grammers-client/Cargo.toml
@@ -18,7 +18,7 @@ markdown = ["pulldown-cmark"]
 html = ["html5ever"]
 proxy = ["grammers-mtsender/proxy"]
 parse_invite_link = ["url"]
-serde = ["grammers-tl-types/impl-serde"]
+serde = ["grammers-tl-types/impl-serde", "grammers-session/impl-serde"]
 fs = ["tokio/fs"]
 default = ["fs"]
 

--- a/lib/grammers-session/Cargo.toml
+++ b/lib/grammers-session/Cargo.toml
@@ -18,6 +18,9 @@ grammers-tl-types = { path = "../grammers-tl-types", version = "0.7.0" }
 grammers-crypto = { path = "../grammers-crypto", version = "0.7.0" }
 log = "0.4.22"
 web-time = "1.1.0"
+serde = { version = "~1.0", optional = true }
+serde_derive = { version = "~1.0", optional = true }
+
 
 [build-dependencies]
 grammers-tl-gen = { path = "../grammers-tl-gen", version = "0.7.0" }
@@ -25,3 +28,7 @@ grammers-tl-parser = { path = "../grammers-tl-parser", version = "1.1.2" }
 
 [dev-dependencies]
 toml = "0.8.19"
+
+[features]
+default = []
+impl-serde = ["dep:serde", "dep:serde_derive"]

--- a/lib/grammers-session/DEPS.md
+++ b/lib/grammers-session/DEPS.md
@@ -32,3 +32,11 @@ Used to test that this file lists all dependencies from `Cargo.toml`.
 
 Used for its web-friendly clock and timer as a replacement for `std::time` in the library.
 Automatically falls back to `std::time` when we're not targeting web.
+
+## serde
+
+Support serde ecosystem.
+
+## serde_derive
+
+Macros that auto generate serde code.

--- a/lib/grammers-session/build.rs
+++ b/lib/grammers-session/build.rs
@@ -38,6 +38,7 @@ fn main() -> std::io::Result<()> {
     .collect::<Vec<_>>();
 
     let config = Config {
+        impl_serde: cfg!(feature = "impl-serde"),
         ..Default::default()
     };
 

--- a/lib/grammers-session/src/chat/packed.rs
+++ b/lib/grammers-session/src/chat/packed.rs
@@ -10,6 +10,7 @@ use grammers_tl_types as tl;
 use std::fmt;
 
 #[repr(u8)]
+#[cfg_attr(feature = "impl-serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PackedType {
     // The fancy bit pattern may enable some optimizations.
@@ -26,6 +27,7 @@ pub enum PackedType {
     Gigagroup = 0b0011_1000,
 }
 
+#[cfg_attr(feature = "impl-serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A packed chat
 pub struct PackedChat {

--- a/lib/grammers-session/src/lib.rs
+++ b/lib/grammers-session/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::Mutex;
 // Needed for auto-generated definitions.
 use grammers_tl_types::{Deserializable, Identifiable, Serializable, deserialize};
 
+#[cfg_attr(feature = "impl-serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
 pub struct Session {
     session: Mutex<types::Session>,
 }

--- a/lib/grammers-tl-types/Cargo.toml
+++ b/lib/grammers-tl-types/Cargo.toml
@@ -12,11 +12,12 @@ repository = "https://github.com/Lonami/grammers"
 keywords = ["telegram", "tl"]
 categories = ["data-structures", "encoding"]
 edition = "2024"
-include = [
-    "build.rs",
-    "src/*.rs",
-    "tl/*.tl",
-]
+include = ["build.rs", "src/*.rs", "tl/*.tl"]
+
+[dependencies]
+serde = { version = "~1.0", optional = true }
+serde_derive = { version = "~1.0", optional = true }
+serde_bytes = { version = "0.11.17", optional = true }
 
 [build-dependencies]
 grammers-tl-gen = { path = "../grammers-tl-gen", version = "0.7.0" }
@@ -35,8 +36,3 @@ impl-from-type = []
 impl-serde = ["dep:serde", "dep:serde_derive", "dep:serde_bytes"]
 tl-api = []
 tl-mtproto = []
-
-[dependencies]
-serde = { version = "1.0.210", optional = true }
-serde_bytes = { version = "0.11.15", optional = true }
-serde_derive = { version = "1.0.210", optional = true }


### PR DESCRIPTION
This PR do 2 things:

1. Add serde support to grammers_session crates, set it as an optional feature.
2. Lock grammers_session and  grammers_tl_types serde dependency from "1.0.xxx" to "~1.0".

I also tried use workspace dependency to lock a fix version of serde, but cargo workspace dependency does not support optional dependency. 