### PR TITLE
Made session storage more abstract

### DIFF
--- a/lib/grammers-client/examples/dialogs.rs
+++ b/lib/grammers-client/examples/dialogs.rs
@@ -46,7 +46,7 @@ async fn async_main() -> Result<()> {
 
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create(SESSION_FILE)?,
+        session: Session::load_from_file_or_create(SESSION_FILE)?,
         api_id,
         api_hash: api_hash.clone(),
         params: Default::default(),
@@ -79,7 +79,7 @@ async fn async_main() -> Result<()> {
             Err(e) => panic!("{}", e),
         };
         println!("Signed in!");
-        match client.session().save_to_file(SESSION_FILE) {
+        match client.session().save() {
             Ok(_) => {}
             Err(e) => {
                 println!("NOTE: failed to save the session, will sign out when done: {e}");

--- a/lib/grammers-client/examples/downloader.rs
+++ b/lib/grammers-client/examples/downloader.rs
@@ -42,7 +42,7 @@ async fn async_main() -> Result<()> {
 
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create(SESSION_FILE)?,
+        session: Session::load_from_file_or_create(SESSION_FILE)?,
         api_id,
         api_hash: api_hash.clone(),
         params: Default::default(),
@@ -75,7 +75,7 @@ async fn async_main() -> Result<()> {
             Err(e) => panic!("{}", e),
         };
         println!("Signed in!");
-        match client.session().save_to_file(SESSION_FILE) {
+        match client.session().save() {
             Ok(_) => {}
             Err(e) => {
                 println!("NOTE: failed to save the session, will sign out when done: {e}");

--- a/lib/grammers-client/examples/echo.rs
+++ b/lib/grammers-client/examples/echo.rs
@@ -50,7 +50,7 @@ async fn async_main() -> Result {
 
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create(SESSION_FILE)?,
+        session: Session::load_from_file_or_create(SESSION_FILE)?,
         api_id,
         api_hash: api_hash.clone(),
         params: InitParams {
@@ -65,7 +65,7 @@ async fn async_main() -> Result {
     if !client.is_authorized().await? {
         println!("Signing in...");
         client.bot_sign_in(&token).await?;
-        client.session().save_to_file(SESSION_FILE)?;
+        client.session().save()?;
         println!("Signed in!");
     }
 
@@ -97,7 +97,7 @@ async fn async_main() -> Result {
     }
 
     println!("Saving session file and exiting...");
-    client.session().save_to_file(SESSION_FILE)?;
+    client.session().save()?;
     Ok(())
 }
 

--- a/lib/grammers-client/examples/inline-pagination.rs
+++ b/lib/grammers-client/examples/inline-pagination.rs
@@ -117,7 +117,7 @@ async fn async_main() -> Result {
 
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create(SESSION_FILE)?,
+        session: Session::load_from_file_or_create(SESSION_FILE)?,
         api_id,
         api_hash: api_hash.clone(),
         params: Default::default(),
@@ -128,7 +128,7 @@ async fn async_main() -> Result {
     if !client.is_authorized().await? {
         println!("Signing in...");
         client.bot_sign_in(&token).await?;
-        client.session().save_to_file(SESSION_FILE)?;
+        client.session().save()?;
         println!("Signed in!");
     }
 
@@ -154,7 +154,7 @@ async fn async_main() -> Result {
     }
 
     println!("Saving session file...");
-    client.session().save_to_file(SESSION_FILE)?;
+    client.session().save()?;
     Ok(())
 }
 

--- a/lib/grammers-client/examples/ping.rs
+++ b/lib/grammers-client/examples/ping.rs
@@ -14,7 +14,7 @@ type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 async fn async_main() -> Result {
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create("ping.session")?,
+        session: Session::load_from_file_or_create("ping.session")?,
         api_id: 1, // not actually logging in, but has to look real
         api_hash: "".to_string(),
         params: Default::default(),

--- a/lib/grammers-client/examples/reconnection.rs
+++ b/lib/grammers-client/examples/reconnection.rs
@@ -29,7 +29,7 @@ impl ReconnectionPolicy for MyPolicy {
 async fn async_main() -> Result {
     println!("Connecting to Telegram...");
     let client = Client::connect(Config {
-        session: Session::load_file_or_create("ping.session")?,
+        session: Session::load_from_file_or_create("ping.session")?,
         api_id: 1, // not actually logging in, but has to look real
         api_hash: "".to_string(),
         params: InitParams {

--- a/lib/grammers-client/src/client/net.rs
+++ b/lib/grammers-client/src/client/net.rs
@@ -191,7 +191,7 @@ impl Client {
     ///
     /// # async fn f() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect(Config {
-    ///     session: Session::load_file_or_create("hello-world.session")?,
+    ///     session: Session::load_from_file_or_create("hello-world.session")?,
     ///     api_id: API_ID,
     ///     api_hash: API_HASH.to_string(),
     ///     params: Default::default(),

--- a/lib/grammers-session/Cargo.toml
+++ b/lib/grammers-session/Cargo.toml
@@ -21,7 +21,8 @@ web-time = "1.1.0"
 serde = { version = "~1.0", optional = true }
 serde_derive = { version = "~1.0", optional = true }
 serde_bytes = { version = "0.11.17", optional = true }
-
+snafu = {version = "0.8.9"}
+base64 = "0.22.1"
 
 [build-dependencies]
 grammers-tl-gen = { path = "../grammers-tl-gen", version = "0.7.0" }

--- a/lib/grammers-session/DEPS.md
+++ b/lib/grammers-session/DEPS.md
@@ -44,3 +44,11 @@ Macros that auto generate serde code.
 ## serde_bytes
 
 Use better bytes encode/decode pattern in serde.
+
+## snafu
+
+Used for more verbose error messages, allowing us to include underlying errors
+
+## base64
+
+Interaction with base64

--- a/lib/grammers-session/src/session_storage/file_storage.rs
+++ b/lib/grammers-session/src/session_storage/file_storage.rs
@@ -1,0 +1,192 @@
+use super::error::*;
+use crate::generated::types;
+use crate::generated::types::Session;
+use crate::session_storage::{SessionProvider, SessionProviderError};
+use grammers_tl_types::{Deserializable, Serializable};
+use std::cmp::PartialEq;
+use std::io::{ErrorKind, Read, Seek, Write};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use snafu::prelude::*;
+
+pub struct FileSessionStorage {
+    file: Arc<Mutex<std::fs::File>>,
+    session: Arc<Mutex<Session>>,
+}
+
+pub enum OpenMode {
+    /// Creates a new file. If the file already exists, an error will occur.
+    /// This mode is used when you need to create a new session file.
+    Create,
+
+    /// Opens an existing file for reading/writing.
+    /// If the file does not exist, an error will occur.
+    Open,
+
+    /// Attempts to create a file if it doesn't exist, or open it if it does.
+    /// Combines the functionality of `Create` and `Open` modes.
+    CreateOpen
+}
+
+/// Used in [`FileSessionStorage::new`] to configure storage
+pub struct FileSessionStorageOptions {
+    /// Path to the file for saving and loading session.
+    /// The path can be either absolute or relative.
+    pub path: Box<dyn AsRef<Path>>,
+
+    /// Specifies the mode for file operations.
+    pub mode: OpenMode,
+
+    /// Holds the session data. When [`FileSessionStorage::load`] is called,
+    /// the session from the file will be loaded into this field.
+    /// When [`FileSessionStorage::save`] is called, the session stored here
+    /// will be written to the file.
+    pub session: Arc<Mutex<Session>>,
+}
+
+impl FileSessionStorage {
+    /// Returns a clone of the [`Arc<Mutex<Session>>`] containing the underlying session data
+    pub fn get_session(&self) -> Arc<Mutex<types::Session>> {
+        self.session.clone()
+    }
+
+    /// Returns a clone of the [`Arc<Mutex<File>>`] representing the file used by the storage.
+    pub fn get_file(&self) -> Arc<Mutex<std::fs::File>> {
+        self.file.clone()
+    }
+
+    /// Creates a new storage instance with default session and specified path.
+    /// ```ignore
+    /// session: Session{
+    ///     dcs: vec![],
+    ///     user: None,
+    ///     state: None,
+    /// },
+    /// path: path,
+    /// mode: OpenMode::CreateOpen
+    /// ```
+    pub fn default_with_path<T: AsRef<Path> + 'static>(path: T) -> Result<Self> {
+        Self::default_with_path_and_session(path, Arc::new(Mutex::new(types::Session{
+            dcs: vec![],
+            user: None,
+            state: None,
+        })))
+    }
+
+    /// Creates a new storage instance with specified path and session.
+    /// ```ignore
+    /// session: session,
+    /// path: path,
+    /// mode: OpenMode::CreateOpen
+    /// ```
+    pub fn default_with_path_and_session<T: AsRef<Path> + 'static>(path: T, session: Arc<Mutex<types::Session>>) -> Result<Self> {
+        Self::new(
+            FileSessionStorageOptions{
+                path: Box::new(path),
+                mode: OpenMode::CreateOpen,
+                session
+            }
+        )
+    }
+
+    pub fn new(options: FileSessionStorageOptions) -> Result<Self> {
+        let path = (*options.path).as_ref().display().to_string();
+        let exists = std::fs::exists(&*options.path).context(UnexpectedIoSnafu)?;
+
+        match options.mode {
+            OpenMode::Create => {
+                ensure!(!exists, AlreadyExistsSnafu { path });
+
+                Ok(Self {
+                    file: Arc::new(Mutex::new(
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .read(true)
+                            .open(&*options.path)
+                            .context(UnexpectedIoSnafu)?
+                    )),
+                    session: options.session,
+                })
+            }
+            OpenMode::Open => {
+                ensure!(exists, NotFoundSnafu { path });
+
+                Ok(Self {
+                    file: Arc::new(Mutex::new(
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .read(true)
+                            .open(&*options.path)
+                            .context(UnexpectedIoSnafu)?,
+                    )),
+                    session: options.session,
+                })
+            }
+            OpenMode::CreateOpen => {
+                let file = match std::fs::OpenOptions::new()
+                    .write(true)
+                    .read(true)
+                    .create(true)
+                    .open(&*options.path)
+                {
+                    Ok(f) => f,
+                    Err(e) => if e.kind() == ErrorKind::NotFound {
+
+                        std::fs::OpenOptions::new()
+                            .write(true)
+                            .read(true)
+                            .open(&*options.path)
+                            .context(UnexpectedIoSnafu)?
+
+                    } else {
+                        Err(e).context(UnexpectedIoSnafu)?
+                    }
+                };
+
+                Ok(Self{file: Arc::new(Mutex::new(file)), session: options.session})
+            }
+        }
+    }
+}
+
+impl SessionProvider for FileSessionStorage {
+    /// Saves the current session data to the underlying file.
+    fn save(&self) -> Result<()> {
+        let session = self.session.lock().unwrap();
+        let mut file = self.file.lock().unwrap();
+        let handle = &mut *file;
+
+        handle.seek(std::io::SeekFrom::Start(0)).context(UnexpectedIoSnafu)?;
+        handle.set_len(0).context(UnexpectedIoSnafu)?;
+        handle.write_all(&session.to_bytes()).context(UnexpectedIoSnafu)?;
+        handle.sync_data().context(UnexpectedIoSnafu)
+    }
+
+    /// Loads session data from the underlying file into the session.
+    fn load(&self) -> Result<()> {
+        let mut session = self.session.lock().unwrap();
+        let mut file = self.file.lock().unwrap();
+        let handle = &mut *file;
+
+        let mut content: Vec<u8> = vec![];
+        handle
+            .read_to_end(&mut content)
+            .context(UnexpectedIoSnafu)?;
+
+        let deserialized_session = Session::from_bytes(&content).context(InvalidFormatSnafu)?;
+
+        *session = deserialized_session;
+
+        Ok(())
+    }
+}
+
+impl PartialEq for OpenMode {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+type Result<T, E = SessionProviderError> = std::result::Result<T, E>;

--- a/lib/grammers-session/src/session_storage/mod.rs
+++ b/lib/grammers-session/src/session_storage/mod.rs
@@ -1,0 +1,44 @@
+pub mod file_storage;
+pub mod string_storage;
+
+use std::io;
+use base64::DecodeError;
+use snafu::{Snafu, prelude::*};
+
+pub trait SessionProvider {
+    /// Save session into the underlying storage
+    fn save(&self) -> Result<(), SessionProviderError>;
+
+    /// Load session from the underlying storage
+    fn load(&self) -> Result<(), SessionProviderError>;
+}
+
+#[derive(Snafu,Debug)]
+#[snafu(visibility(pub(crate)))]
+#[snafu(module(error))]
+pub enum SessionProviderError {
+    #[snafu(display("Specified path \"{path}\" not found"))]
+    NotFound { path: String },
+
+    #[snafu(display("Specified path \"{path}\" already exists"))]
+    AlreadyExists { path: String },
+
+    #[snafu(display("Error while converting bytes into session occurred"))]
+    InvalidFormat {
+        source: grammers_tl_types::deserialize::Error,
+    },
+
+    #[snafu(display("Unexpected IO error occurred"))]
+    UnexpectedIoError {
+        source: io::Error
+    },
+
+    #[snafu(display("Error while converting base64 string {string} into bytes"))]
+    DecodeStringError{
+        source: DecodeError,
+        string: String
+    },
+
+    #[snafu(display("Strange argument has been passed : {}", if let Some(explanation) = explanation { explanation.to_owned() } else { "no explanation".to_string() }))]
+    BadArgument { explanation: Option<String> },
+}

--- a/lib/grammers-session/src/session_storage/string_storage.rs
+++ b/lib/grammers-session/src/session_storage/string_storage.rs
@@ -1,0 +1,102 @@
+use std::sync::{Arc, Mutex};
+use base64::Engine;
+use snafu::{Snafu, prelude::*};
+use grammers_tl_types::{Deserializable, Serializable};
+use crate::session_storage::{SessionProvider, SessionProviderError};
+use crate::session_storage::error::{DecodeStringSnafu, InvalidFormatSnafu};
+
+/// String-based session storage implementation
+///
+/// This structure provides session data storage in the form of a base64-encoded string.
+pub struct StringSessionStorage {
+    /// String for storing encoded session data
+    string: Arc<Mutex<String>>,
+
+    /// Underlying session
+    session: Arc<Mutex<crate::types::Session>>
+}
+
+/// Options for [`StringSessionStorage::new`]
+pub struct StringSessionStorageOptions {
+    /// Optional storage string
+    ///
+    /// If not provided, an empty string will be created
+    pub string: Option<Arc<Mutex<String>>>,
+
+    /// Optional initial session
+    ///
+    /// If not provided, an empty session with default values will be created
+    pub session: Option<Arc<Mutex<crate::types::Session>>>
+}
+
+impl StringSessionStorage {
+    pub fn new(options: StringSessionStorageOptions) -> Self {
+        Self {
+            string: if let Some(string) = options.string {
+                string
+            } else {
+                Arc::new(Mutex::new(String::new()))
+            },
+            session: if let Some(session) = options.session {
+                session
+            } else {
+                Arc::new(
+                    Mutex::new(
+                        crate::types::Session {
+                            dcs: vec![],
+                            user: None,
+                            state: None,
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    /// Returns a clone of Arc<Mutex<String>>
+    pub fn get_string(&self) -> Arc<Mutex<String>> {
+        self.string.clone()
+    }
+
+    /// Returns a clone of Arc<Mutex<Session>>
+    pub fn get_session(&self) -> Arc<Mutex<crate::types::Session>> {
+        self.session.clone()
+    }
+
+}
+
+impl SessionProvider for StringSessionStorage {
+    fn save(&self) -> std::result::Result<(), SessionProviderError> {
+        let session_ref = self.session.clone();
+        let session = session_ref.lock().unwrap();
+
+        let string_ref = self.string.clone();
+        let mut string = string_ref.lock().unwrap();
+
+        (&mut *string).truncate(0);
+        base64::prelude::BASE64_STANDARD.encode_string(&*session.to_bytes(), &mut *string);
+
+        Ok(())
+
+    }
+
+    fn load(&self) -> std::result::Result<(), SessionProviderError> {
+        let session_ref = self.session.clone();
+        let mut session = session_ref.lock().unwrap();
+
+        let string_ref = self.string.clone();
+        let string = string_ref.lock().unwrap();
+
+        let mut output: Vec<u8> = vec![];
+        base64::prelude::BASE64_STANDARD.decode_vec(&*string, &mut output).context(DecodeStringSnafu{
+            string: (*string).clone()
+        })?;
+
+        let new_session = crate::types::Session::from_bytes(&output).context(InvalidFormatSnafu)?;
+        *session = new_session;
+
+        Ok(())
+    }
+}
+
+type Result<T, E = SessionProviderError> = std::result::Result<T, E>;


### PR DESCRIPTION
I found current implementation of session storage some kind of ugly because of breaking SOLID principles. 

### Changes made:
- Created `SessionProvider` trait, providing some methods for the storage to implement
- Introduced `snafu` dependency to keep occurring errors more verbose
- Implemented `FileSessionStorage` and `StringSessionStorage`
- Fixed dependants of the session crate
- Implemented helpers for the session to create appropriate storages

P.S. StringSessionStorage might look strange, but i think it's possible to improve it in the future :)