### PR TITLE
Use `IntoIterator` instead of `Vec` in parameter types for public API

### DIFF
--- a/lib/grammers-client/src/parsers/common.rs
+++ b/lib/grammers-client/src/parsers/common.rs
@@ -142,7 +142,12 @@ pub fn after(index: usize, part: u8, offset: i32) -> Position {
 /// Inject multiple text segments into a message.
 ///
 /// The insertions do not need to be sorted before-hand, as this method takes care of that.
-pub fn inject_into_message(message: &str, mut insertions: Vec<(Position, Segment)>) -> String {
+pub fn inject_into_message<'a, I>(message: &str, insertions: I) -> String
+where
+    I: IntoIterator<Item = (Position, Segment<'a>)>,
+{
+    let mut insertions = insertions.into_iter().collect::<Vec<_>>();
+
     // Allocate exactly as much as needed, then walk through the UTF-16-encoded message,
     // applying insertions at the exact position they occur.
     let mut result = String::with_capacity(

--- a/lib/grammers-client/src/types/chat_map.rs
+++ b/lib/grammers-client/src/types/chat_map.rs
@@ -41,7 +41,11 @@ pub struct ChatMap {
 
 impl ChatMap {
     /// Create a new chat set.
-    pub fn new(users: Vec<tl::enums::User>, chats: Vec<tl::enums::Chat>) -> Arc<Self> {
+    pub fn new<U, C>(users: U, chats: C) -> Arc<Self>
+    where
+        U: IntoIterator<Item = tl::enums::User>,
+        C: IntoIterator<Item = tl::enums::Chat>,
+    {
         Arc::new(Self {
             map: users
                 .into_iter()

--- a/lib/grammers-client/src/types/input_media.rs
+++ b/lib/grammers-client/src/types/input_media.rs
@@ -44,8 +44,11 @@ impl InputMedia {
     }
 
     /// The formatting entities within the caption (such as bold, italics, etc.).
-    pub fn fmt_entities(mut self, entities: Vec<tl::enums::MessageEntity>) -> Self {
-        self.entities = entities;
+    pub fn fmt_entities<I>(mut self, entities: I) -> Self
+    where
+        I: IntoIterator<Item = tl::enums::MessageEntity>,
+    {
+        self.entities = entities.into_iter().collect();
         self
     }
 

--- a/lib/grammers-client/src/types/input_message.rs
+++ b/lib/grammers-client/src/types/input_message.rs
@@ -69,8 +69,11 @@ impl InputMessage {
     }
 
     /// The formatting entities within the message (such as bold, italics, etc.).
-    pub fn fmt_entities(mut self, entities: Vec<tl::enums::MessageEntity>) -> Self {
-        self.entities = entities;
+    pub fn fmt_entities<I>(mut self, entities: I) -> Self
+    where
+        I: IntoIterator<Item = tl::enums::MessageEntity>,
+    {
+        self.entities = entities.into_iter().collect();
         self
     }
 


### PR DESCRIPTION
This PR changes `Vec` parameter types for public API to `IntoIterator` for better interactivity, because `IntoIterator` accepts more collectable types, such as slice (`[T]`, `&[T]`), iterators, etc.