### PR TITLE
In-place AES-IGE decryption

### DIFF
--- a/grammers-crypto/src/aes.rs
+++ b/grammers-crypto/src/aes.rs
@@ -6,89 +6,84 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
+
 //! [AES-Infinite Garble Extension](https://mgp25.com/blog/2015/06/21/AESIGE/) implementation.
 
-#[allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use std::mem;
 
+use aes::Aes256;
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+
 /// Encrypt the input plaintext in-place using the AES-IGE mode.
+/// The buffer length must be a multiple of 16.
 pub fn ige_encrypt(buffer: &mut [u8], key: &[u8; 32], iv: &[u8; 32]) {
-    assert!(buffer.len() % 16 == 0);
+    assert_eq!(buffer.len() % 16, 0);
 
-    #[allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
-    let key = GenericArray::from_slice(key);
-    let cipher = aes::Aes256::new(key);
+    let cipher = Aes256::new(GenericArray::from_slice(key));
 
-    let mut plaintext_block = [0; 16];
-    let mut iv1 = [0; 16];
-    let mut iv2 = [0; 16];
-    iv1.copy_from_slice(&iv[..16]);
-    iv2.copy_from_slice(&iv[16..]);
+    let mut iv1: [u8; 16] = iv[0..16].try_into().unwrap();
+    let mut iv2: [u8; 16] = iv[16..32].try_into().unwrap();
 
-    for ciphertext_block in buffer.chunks_mut(16) {
-        plaintext_block.copy_from_slice(ciphertext_block);
+    let mut next_iv2 = [0u8; 16];
 
-        // block = block XOR iv1
-        ciphertext_block
-            .iter_mut()
-            .zip(plaintext_block)
-            .zip(iv1.as_ref())
-            .for_each(|((x, a), b)| *x = a ^ b);
+    for block in buffer.chunks_mut(16) {
+        // next iv2 = block (plaintext)
+        next_iv2.copy_from_slice(block);
 
-        // block = encrypt(block);
-        #[allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
-        let ciphertext_block = GenericArray::from_mut_slice(ciphertext_block);
-        cipher.encrypt_block(ciphertext_block);
+        // block (plaintext) XOR iv1 (previous ciphertext)
+        for i in 0..16 {
+            block[i] ^= iv1[i]
+        }
 
-        // block = block XOR iv2
-        ciphertext_block
-            .iter_mut()
-            .zip(iv2.as_ref())
-            .for_each(|(x, a)| *x ^= a);
+        cipher.encrypt_block(GenericArray::from_mut_slice(block));
 
-        // save ciphertext and adjust iv
-        iv1.copy_from_slice(ciphertext_block);
-        mem::swap(&mut iv2, &mut plaintext_block);
+        // block (ciphertext) XOR iv2 (previous plaintext)
+        for i in 0..16 {
+            block[i] ^= iv2[i]
+        }
+
+        // iv1 = block (ciphertext)
+        iv1.copy_from_slice(block);
+
+        // iv2 = next iv2 (plaintext)
+        mem::swap(&mut iv2, &mut next_iv2);
     }
 }
 
-/// Decrypt the input ciphertext using the AES-IGE mode.
-pub fn ige_decrypt(ciphertext: &[u8], key: &[u8; 32], iv: &[u8; 32]) -> Vec<u8> {
-    let size = ciphertext.len();
-    assert!(size % 16 == 0);
-    let mut plaintext = vec![0; size];
+/// Decrypt the input ciphertext in-place using the AES-IGE mode.
+/// The buffer length must be a multiple of 16.
+pub fn ige_decrypt(buffer: &mut [u8], key: &[u8; 32], iv: &[u8; 32]) {
+    assert_eq!(buffer.len() % 16, 0);
 
-    #[allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
-    let key = GenericArray::from_slice(key);
-    let cipher = aes::Aes256::new(key);
-    let mut iv = *iv;
-    let (iv1, iv2) = iv.split_at_mut(16);
+    let cipher = Aes256::new(GenericArray::from_slice(key));
 
-    for (ciphertext_block, plaintext_block) in ciphertext.chunks(16).zip(plaintext.chunks_mut(16)) {
-        // block = block XOR iv2
-        plaintext_block
-            .iter_mut()
-            .zip(ciphertext_block)
-            .zip(iv2.as_ref())
-            .for_each(|((a, x), b)| *a = x ^ b);
+    let mut iv1: [u8; 16] = iv[0..16].try_into().unwrap();
+    let mut iv2: [u8; 16] = iv[16..32].try_into().unwrap();
 
-        // block = decrypt(block);
-        #[allow(deprecated)] // see https://github.com/RustCrypto/block-ciphers/issues/509
-        let plaintext_block = GenericArray::from_mut_slice(plaintext_block);
-        cipher.decrypt_block(plaintext_block);
+    let mut next_iv1 = [0u8; 16];
 
-        // block = block XOR iv1
-        plaintext_block
-            .iter_mut()
-            .zip(iv1.as_ref())
-            .for_each(|(a, b)| *a ^= b);
+    for block in buffer.chunks_mut(16) {
+        // next iv1 = block (ciphertext)
+        next_iv1.copy_from_slice(block);
 
-        // save plaintext and adjust iv
-        iv1.copy_from_slice(ciphertext_block);
-        iv2.copy_from_slice(plaintext_block);
+        // block (ciphertext) XOR iv2 (previous plaintext)
+        for i in 0..16 {
+            block[i] ^= iv2[i]
+        }
+
+        cipher.decrypt_block(GenericArray::from_mut_slice(block));
+
+        // block (plaintext) XOR iv1 (previous ciphertext)
+        for i in 0..16 {
+            block[i] ^= iv1[i]
+        }
+
+        // iv1 = next iv1 (ciphertext)
+        mem::swap(&mut iv1, &mut next_iv1);
+
+        // iv2 = block (plaintext)
+        iv2.copy_from_slice(block);
     }
-
-    plaintext
 }

--- a/grammers-crypto/src/rsa.rs
+++ b/grammers-crypto/src/rsa.rs
@@ -12,7 +12,7 @@
 
 use num_bigint::BigUint;
 
-use crate::{aes::ige_encrypt, sha256};
+use crate::{aes, sha256};
 
 /// RSA key.
 pub struct Key {
@@ -76,7 +76,7 @@ pub fn encrypt_hashed(data: &[u8], key: &Key, random_bytes: &[u8; 224]) -> Vec<u
         };
 
         // aes_encrypted := AES256_IGE(data_with_hash, temp_key, 0); -- AES256-IGE encryption with zero IV.
-        ige_encrypt(data_with_hash.as_mut(), &temp_key, &[0u8; 32]);
+        aes::ige_encrypt(data_with_hash.as_mut(), &temp_key, &[0u8; 32]);
         let aes_encrypted = data_with_hash;
 
         // temp_key_xor := temp_key XOR SHA256(aes_encrypted); -- adjusted key, 32 bytes

--- a/grammers-mtproto/src/mtp/encrypted.rs
+++ b/grammers-mtproto/src/mtp/encrypted.rs
@@ -1292,10 +1292,15 @@ impl Mtp for Encrypted {
     }
 
     /// Processes an encrypted response from the server.
-    fn deserialize(&mut self, payload: &[u8]) -> Result<Vec<Deserialization>, DeserializeError> {
+    fn deserialize(
+        &mut self,
+        payload: &mut [u8],
+    ) -> Result<Vec<Deserialization>, DeserializeError> {
         crate::utils::check_message_buffer(payload)?;
 
-        let plaintext = decrypt_data_v2(payload, &self.auth_key)?;
+        let plaintext_range = decrypt_data_v2(payload, &self.auth_key)?;
+        let plaintext = &payload[plaintext_range];
+
         let mut buffer = Cursor::from_slice(&plaintext[..]);
 
         let _salt = i64::deserialize(&mut buffer)?;

--- a/grammers-mtproto/src/mtp/mod.rs
+++ b/grammers-mtproto/src/mtp/mod.rs
@@ -218,5 +218,6 @@ pub trait Mtp {
     fn finalize(&mut self, buffer: &mut DequeBuffer<u8>) -> Option<MsgId>;
 
     /// Deserializes a single incoming message payload into zero or more responses.
-    fn deserialize(&mut self, payload: &[u8]) -> Result<Vec<Deserialization>, DeserializeError>;
+    fn deserialize(&mut self, payload: &mut [u8])
+    -> Result<Vec<Deserialization>, DeserializeError>;
 }

--- a/grammers-mtproto/src/mtp/plain.rs
+++ b/grammers-mtproto/src/mtp/plain.rs
@@ -72,7 +72,10 @@ impl Mtp for Plain {
     /// if it is, the method returns the inner contents of the message.
     ///
     /// [`serialize_plain_message`]: #method.serialize_plain_message
-    fn deserialize(&mut self, payload: &[u8]) -> Result<Vec<Deserialization>, DeserializeError> {
+    fn deserialize(
+        &mut self,
+        payload: &mut [u8],
+    ) -> Result<Vec<Deserialization>, DeserializeError> {
         crate::utils::check_message_buffer(payload)?;
 
         let mut buf = Cursor::from_slice(payload);

--- a/grammers-mtsender/src/sender.rs
+++ b/grammers-mtsender/src/sender.rs
@@ -305,7 +305,7 @@ impl<T: Transport, M: Mtp> Sender<T, M> {
                     debug!("deserializing valid transport packet...");
                     let result = self
                         .mtp
-                        .deserialize(&self.read_buffer[next_offset..][offset.data_range])?;
+                        .deserialize(&mut self.read_buffer[next_offset..][offset.data_range])?;
 
                     self.process_mtp_buffer(result, &mut updates);
                     next_offset += offset.next_offset;


### PR DESCRIPTION
Made grammers_crypto::aes::ige_decrypt work in-place.

Removed grammers_crypto::{encrypt_ige, decrypt_ige}.

Tests pass, examples work.