### PR TITLE
Deny potential integer overflows

### DIFF
--- a/grammers-crypto/src/factorize.rs
+++ b/grammers-crypto/src/factorize.rs
@@ -109,6 +109,7 @@ fn factorize_with_param(pq: u64, c: u64) -> (u64, u64) {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)]
     let (p, q) = (g as u64, (pq / g) as u64);
     (p.min(q), p.max(q))
 }

--- a/grammers-crypto/src/lib.rs
+++ b/grammers-crypto/src/lib.rs
@@ -9,7 +9,7 @@
 //! This library contains a collection of functions that relate to
 //! encrypting and decryption values when exchanging messages with Telegram.
 
-#![deny(unsafe_code)]
+#![deny(unsafe_code, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 pub mod aes;
 mod auth_key;

--- a/grammers-crypto/src/two_factor_auth.rs
+++ b/grammers-crypto/src/two_factor_auth.rs
@@ -37,12 +37,13 @@ pub fn calculate_2fa(
     let g_b = pad_to_256(&g_b);
     let a = pad_to_256(&a);
 
-    let g_for_hash = vec![*g as u8];
+    #[expect(clippy::cast_possible_truncation)]
+    let g_for_hash = vec![g.cast_unsigned() as u8];
     let g_for_hash = pad_to_256(&g_for_hash);
 
     let big_g_b = BigInt::from_bytes_be(Sign::Plus, &g_b);
 
-    let big_g = BigInt::from(*g as u32);
+    let big_g = BigInt::from(g.cast_unsigned());
     let big_a = BigInt::from_bytes_be(Sign::Plus, &a);
 
     // k := H(p | g)

--- a/grammers-mtproto/src/authentication.rs
+++ b/grammers-mtproto/src/authentication.rs
@@ -366,10 +366,12 @@ pub fn step3(
         println!("r {}", hex::to_hex(&random_bytes));
     }
 
-    let now = SystemTime::now()
+    let now: i32 = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time is before epoch")
-        .as_secs() as i32;
+        .as_secs()
+        .try_into()
+        .unwrap();
 
     let res = do_step3(data, response, &random_bytes, now);
     if TRACE_AUTH_GEN {

--- a/grammers-mtproto/src/lib.rs
+++ b/grammers-mtproto/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! [Mobile Transport Protocol]: https://core.telegram.org/mtproto
 
-#![deny(unsafe_code)]
+#![deny(unsafe_code, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 pub mod authentication;
 mod manual_tl;

--- a/grammers-mtsender/src/lib.rs
+++ b/grammers-mtsender/src/lib.rs
@@ -21,7 +21,7 @@
 //! although many tasks can share access to the same `SenderPool` via
 //! multiple [`SenderPoolHandle`]s.
 
-#![deny(unsafe_code)]
+#![deny(unsafe_code, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 
 mod configuration;
 mod errors;

--- a/grammers-mtsender/src/sender.rs
+++ b/grammers-mtsender/src/sender.rs
@@ -62,6 +62,10 @@ pub(crate) fn generate_random_id() -> i64 {
     static LAST_ID: AtomicI64 = AtomicI64::new(0);
 
     while LAST_ID.load(Ordering::SeqCst) == 0 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "truncation is absolutely allowed for generating ping IDs"
+        )]
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system time is before epoch")

--- a/grammers-mtsender/src/sender_pool.rs
+++ b/grammers-mtsender/src/sender_pool.rs
@@ -342,7 +342,7 @@ impl SenderPoolRunner {
                         .ip_address
                         .parse()
                         .expect("Telegram to return a valid IPv6 address"),
-                    option.port as _,
+                    u16::try_from(option.port).expect("Telegram to return a valid port"),
                     0,
                     0,
                 );
@@ -352,7 +352,7 @@ impl SenderPoolRunner {
                         .ip_address
                         .parse()
                         .expect("Telegram to return a valid IPv4 address"),
-                    option.port as _,
+                    u16::try_from(option.port).expect("Telegram to return a valid port"),
                 );
                 if dc_option.ipv6.ip().to_bits() == 0 {
                     dc_option.ipv6 = SocketAddrV6::new(


### PR DESCRIPTION
In short, use `i32::try_from(some_usize_var).unwrap()` instead of `some_usize_var as i32` to avoid potential integer overflow in `grammers-crypto`, `grammers-mtproto` and `grammers-mtender`.

Added `#[deny(clippy::cast_possible_truncation, clippy::cast_sign_loss)]` to enforce these rules and `#[expect]` for statements where integer overflow is acceptable or impossible.

It is much better to panic than to continue with bad data.