### PR TITLE
Disable unused libsql features

### DIFF
--- a/grammers-session/Cargo.toml
+++ b/grammers-session/Cargo.toml
@@ -18,7 +18,7 @@ futures-core = "0.3.31"
 grammers-tl-types = { path = "../grammers-tl-types", version = "0.8.0" }
 log = "0.4.28"
 
-libsql = { version = "0.9.29", optional = true }
+libsql = { version = "0.9.29", default-features = false, features = ["core"], optional = true }
 tokio = { version = "1.47.1", default-features = false }
 
 serde = { version = "1", features = ["derive"], optional = true }


### PR DESCRIPTION
Since we do not utilize any of the libsql networking or replication features, we can safely disable the default features.

<details>
<summary><b>See Dependency Diff</b></summary>

### Before:

```
grammers-session v0.8.0 (/home/aykut/dev/grammers/grammers-session)
├── futures-core v0.3.31
├── grammers-tl-types v0.8.0 (/home/aykut/dev/grammers/grammers-tl-types)
├── libsql v0.9.29
│   ├── anyhow v1.0.100
│   ├── async-stream v0.3.6
│   │   ├── async-stream-impl v0.3.6 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.93
│   │   │   │   └── unicode-ident v1.0.12
│   │   │   ├── quote v1.0.36
│   │   │   │   └── proc-macro2 v1.0.93 (*)
│   │   │   └── syn v2.0.98
│   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │       ├── quote v1.0.36 (*)
│   │   │       └── unicode-ident v1.0.12
│   │   ├── futures-core v0.3.31
│   │   └── pin-project-lite v0.2.14
│   ├── async-trait v0.1.81 (proc-macro)
│   │   ├── proc-macro2 v1.0.93 (*)
│   │   ├── quote v1.0.36 (*)
│   │   └── syn v2.0.98 (*)
│   ├── base64 v0.21.7
│   ├── bincode v1.3.3
│   │   └── serde v1.0.228
│   │       ├── serde_core v1.0.228
│   │       └── serde_derive v1.0.228 (proc-macro)
│   │           ├── proc-macro2 v1.0.93 (*)
│   │           ├── quote v1.0.36 (*)
│   │           └── syn v2.0.98 (*)
│   ├── bitflags v2.6.0
│   ├── bytes v1.11.0
│   │   └── serde v1.0.228 (*)
│   ├── chrono v0.4.43
│   │   ├── iana-time-zone v0.1.60
│   │   └── num-traits v0.2.19
│   ├── crc32fast v1.5.0
│   │   └── cfg-if v1.0.0
│   ├── fallible-iterator v0.3.0
│   ├── futures v0.3.31
│   │   ├── futures-channel v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   └── futures-sink v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-executor v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-task v0.3.31
│   │   │   └── futures-util v0.3.31
│   │   │       ├── futures-channel v0.3.31 (*)
│   │   │       ├── futures-core v0.3.31
│   │   │       ├── futures-io v0.3.31
│   │   │       ├── futures-macro v0.3.31 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.93 (*)
│   │   │       │   ├── quote v1.0.36 (*)
│   │   │       │   └── syn v2.0.98 (*)
│   │   │       ├── futures-sink v0.3.31
│   │   │       ├── futures-task v0.3.31
│   │   │       ├── memchr v2.7.4
│   │   │       ├── pin-project-lite v0.2.14
│   │   │       ├── pin-utils v0.1.0
│   │   │       └── slab v0.4.9
│   │   ├── futures-io v0.3.31
│   │   ├── futures-sink v0.3.31
│   │   ├── futures-task v0.3.31
│   │   └── futures-util v0.3.31 (*)
│   ├── http v0.2.12
│   │   ├── bytes v1.11.0 (*)
│   │   ├── fnv v1.0.7
│   │   └── itoa v1.0.11
│   ├── hyper v0.14.32
│   │   ├── bytes v1.11.0 (*)
│   │   ├── futures-channel v0.3.31 (*)
│   │   ├── futures-core v0.3.31
│   │   ├── futures-util v0.3.31 (*)
│   │   ├── h2 v0.3.27
│   │   │   ├── bytes v1.11.0 (*)
│   │   │   ├── fnv v1.0.7
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-sink v0.3.31
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── http v0.2.12 (*)
│   │   │   ├── indexmap v2.13.0
│   │   │   │   ├── equivalent v1.0.1
│   │   │   │   └── hashbrown v0.16.1
│   │   │   ├── slab v0.4.9
│   │   │   ├── tokio v1.49.0
│   │   │   │   ├── bytes v1.11.0 (*)
│   │   │   │   ├── libc v0.2.180
│   │   │   │   ├── mio v1.0.1
│   │   │   │   │   └── libc v0.2.180
│   │   │   │   ├── parking_lot v0.12.3
│   │   │   │   │   ├── lock_api v0.4.12
│   │   │   │   │   │   └── scopeguard v1.2.0
│   │   │   │   │   └── parking_lot_core v0.9.10
│   │   │   │   │       ├── cfg-if v1.0.0
│   │   │   │   │       ├── libc v0.2.180
│   │   │   │   │       └── smallvec v1.13.2
│   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   ├── signal-hook-registry v1.4.2
│   │   │   │   │   └── libc v0.2.180
│   │   │   │   ├── socket2 v0.6.2
│   │   │   │   │   └── libc v0.2.180
│   │   │   │   └── tokio-macros v2.6.0 (proc-macro)
│   │   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │   │       ├── quote v1.0.36 (*)
│   │   │   │       └── syn v2.0.98 (*)
│   │   │   ├── tokio-util v0.7.18
│   │   │   │   ├── bytes v1.11.0 (*)
│   │   │   │   ├── futures-core v0.3.31
│   │   │   │   ├── futures-sink v0.3.31
│   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   └── tokio v1.49.0 (*)
│   │   │   └── tracing v0.1.40
│   │   │       ├── log v0.4.29
│   │   │       ├── pin-project-lite v0.2.14
│   │   │       ├── tracing-attributes v0.1.31 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.93 (*)
│   │   │       │   ├── quote v1.0.36 (*)
│   │   │       │   └── syn v2.0.98 (*)
│   │   │       └── tracing-core v0.1.32
│   │   │           └── once_cell v1.21.3
│   │   ├── http v0.2.12 (*)
│   │   ├── http-body v0.4.6
│   │   │   ├── bytes v1.11.0 (*)
│   │   │   ├── http v0.2.12 (*)
│   │   │   └── pin-project-lite v0.2.14
│   │   ├── httparse v1.10.1
│   │   ├── httpdate v1.0.3
│   │   ├── itoa v1.0.11
│   │   ├── pin-project-lite v0.2.14
│   │   ├── socket2 v0.5.7
│   │   │   └── libc v0.2.180
│   │   ├── tokio v1.49.0 (*)
│   │   ├── tower-service v0.3.3
│   │   ├── tracing v0.1.40 (*)
│   │   └── want v0.3.1
│   │       └── try-lock v0.2.5
│   ├── hyper-rustls v0.25.0
│   │   ├── futures-util v0.3.31 (*)
│   │   ├── http v0.2.12 (*)
│   │   ├── hyper v0.14.32 (*)
│   │   ├── log v0.4.29
│   │   ├── rustls v0.22.4
│   │   │   ├── log v0.4.29
│   │   │   ├── ring v0.17.11
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   ├── getrandom v0.2.15
│   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   └── libc v0.2.180
│   │   │   │   └── untrusted v0.9.0
│   │   │   ├── rustls-pki-types v1.14.0
│   │   │   │   └── zeroize v1.8.2
│   │   │   ├── rustls-webpki v0.102.8
│   │   │   │   ├── ring v0.17.11 (*)
│   │   │   │   ├── rustls-pki-types v1.14.0 (*)
│   │   │   │   └── untrusted v0.9.0
│   │   │   ├── subtle v2.6.1
│   │   │   └── zeroize v1.8.2
│   │   ├── rustls-native-certs v0.7.3
│   │   │   ├── openssl-probe v0.1.6
│   │   │   ├── rustls-pemfile v2.2.0
│   │   │   │   └── rustls-pki-types v1.14.0 (*)
│   │   │   └── rustls-pki-types v1.14.0 (*)
│   │   ├── rustls-pki-types v1.14.0 (*)
│   │   ├── tokio v1.49.0 (*)
│   │   ├── tokio-rustls v0.25.0
│   │   │   ├── rustls v0.22.4 (*)
│   │   │   ├── rustls-pki-types v1.14.0 (*)
│   │   │   └── tokio v1.49.0 (*)
│   │   └── webpki-roots v0.26.11
│   │       └── webpki-roots v1.0.5
│   │           └── rustls-pki-types v1.14.0 (*)
│   ├── libsql-hrana v0.9.29
│   │   ├── base64 v0.21.7
│   │   ├── bytes v1.11.0 (*)
│   │   ├── prost v0.12.6
│   │   │   ├── bytes v1.11.0 (*)
│   │   │   └── prost-derive v0.12.6 (proc-macro)
│   │   │       ├── anyhow v1.0.100
│   │   │       ├── itertools v0.12.1
│   │   │       │   └── either v1.13.0
│   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │       ├── quote v1.0.36 (*)
│   │   │       └── syn v2.0.98 (*)
│   │   └── serde v1.0.228 (*)
│   ├── libsql-sqlite3-parser v0.13.0
│   │   ├── bitflags v2.6.0
│   │   ├── fallible-iterator v0.3.0
│   │   ├── indexmap v2.13.0 (*)
│   │   ├── log v0.4.29
│   │   ├── memchr v2.7.4
│   │   ├── phf v0.11.3
│   │   │   └── phf_shared v0.11.3
│   │   │       ├── siphasher v1.0.1
│   │   │       └── uncased v0.9.10
│   │   └── uncased v0.9.10
│   ├── libsql-sys v0.9.29
│   │   ├── bytes v1.11.0 (*)
│   │   ├── libsql-ffi v0.9.29
│   │   ├── libsql-rusqlite v0.9.29
│   │   │   ├── bitflags v2.6.0
│   │   │   ├── fallible-iterator v0.2.0
│   │   │   ├── fallible-streaming-iterator v0.1.9
│   │   │   ├── hashlink v0.8.4
│   │   │   │   └── hashbrown v0.14.5
│   │   │   │       ├── ahash v0.8.12
│   │   │   │       │   ├── cfg-if v1.0.0
│   │   │   │       │   ├── once_cell v1.21.3
│   │   │   │       │   └── zerocopy v0.8.27
│   │   │   │       └── allocator-api2 v0.2.21
│   │   │   ├── libsql-ffi v0.9.29
│   │   │   └── smallvec v1.13.2
│   │   ├── once_cell v1.21.3
│   │   ├── tracing v0.1.40 (*)
│   │   └── zerocopy v0.7.35
│   │       ├── byteorder v1.5.0
│   │       └── zerocopy-derive v0.7.35 (proc-macro)
│   │           ├── proc-macro2 v1.0.93 (*)
│   │           ├── quote v1.0.36 (*)
│   │           └── syn v2.0.98 (*)
│   ├── libsql_replication v0.9.29
│   │   ├── aes v0.8.4
│   │   │   ├── cfg-if v1.0.0
│   │   │   ├── cipher v0.4.4
│   │   │   │   ├── crypto-common v0.1.6
│   │   │   │   │   ├── generic-array v0.14.7
│   │   │   │   │   │   └── typenum v1.17.0
│   │   │   │   │   └── typenum v1.17.0
│   │   │   │   └── inout v0.1.3
│   │   │   │       ├── block-padding v0.3.3
│   │   │   │       │   └── generic-array v0.14.7 (*)
│   │   │   │       └── generic-array v0.14.7 (*)
│   │   │   └── cpufeatures v0.2.12
│   │   ├── async-stream v0.3.6 (*)
│   │   ├── async-trait v0.1.81 (proc-macro) (*)
│   │   ├── bytes v1.11.0 (*)
│   │   ├── cbc v0.1.2
│   │   │   └── cipher v0.4.4 (*)
│   │   ├── libsql-rusqlite v0.9.29 (*)
│   │   ├── libsql-sys v0.9.29 (*)
│   │   ├── parking_lot v0.12.3 (*)
│   │   ├── prost v0.12.6 (*)
│   │   ├── serde v1.0.228 (*)
│   │   ├── thiserror v1.0.63
│   │   │   └── thiserror-impl v1.0.63 (proc-macro)
│   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │       ├── quote v1.0.36 (*)
│   │   │       └── syn v2.0.98 (*)
│   │   ├── tokio v1.49.0 (*)
│   │   ├── tokio-stream v0.1.18
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── pin-project-lite v0.2.14
│   │   │   └── tokio v1.49.0 (*)
│   │   ├── tokio-util v0.7.18 (*)
│   │   ├── tonic v0.11.0
│   │   │   ├── async-stream v0.3.6 (*)
│   │   │   ├── async-trait v0.1.81 (proc-macro) (*)
│   │   │   ├── axum v0.6.20
│   │   │   │   ├── async-trait v0.1.81 (proc-macro) (*)
│   │   │   │   ├── axum-core v0.3.4
│   │   │   │   │   ├── async-trait v0.1.81 (proc-macro) (*)
│   │   │   │   │   ├── bytes v1.11.0 (*)
│   │   │   │   │   ├── futures-util v0.3.31 (*)
│   │   │   │   │   ├── http v0.2.12 (*)
│   │   │   │   │   ├── http-body v0.4.6 (*)
│   │   │   │   │   ├── mime v0.3.17
│   │   │   │   │   ├── tower-layer v0.3.3
│   │   │   │   │   └── tower-service v0.3.3
│   │   │   │   ├── bitflags v1.3.2
│   │   │   │   ├── bytes v1.11.0 (*)
│   │   │   │   ├── futures-util v0.3.31 (*)
│   │   │   │   ├── http v0.2.12 (*)
│   │   │   │   ├── http-body v0.4.6 (*)
│   │   │   │   ├── hyper v0.14.32 (*)
│   │   │   │   ├── itoa v1.0.11
│   │   │   │   ├── matchit v0.7.3
│   │   │   │   ├── memchr v2.7.4
│   │   │   │   ├── mime v0.3.17
│   │   │   │   ├── percent-encoding v2.3.2
│   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   ├── serde v1.0.228 (*)
│   │   │   │   ├── sync_wrapper v0.1.2
│   │   │   │   ├── tower v0.4.13
│   │   │   │   │   ├── futures-core v0.3.31
│   │   │   │   │   ├── futures-util v0.3.31 (*)
│   │   │   │   │   ├── indexmap v1.9.3
│   │   │   │   │   │   └── hashbrown v0.12.3
│   │   │   │   │   ├── pin-project v1.1.10
│   │   │   │   │   │   └── pin-project-internal v1.1.10 (proc-macro)
│   │   │   │   │   │       ├── proc-macro2 v1.0.93 (*)
│   │   │   │   │   │       ├── quote v1.0.36 (*)
│   │   │   │   │   │       └── syn v2.0.98 (*)
│   │   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   │   ├── rand v0.8.5
│   │   │   │   │   │   ├── libc v0.2.180
│   │   │   │   │   │   ├── rand_chacha v0.3.1
│   │   │   │   │   │   │   ├── ppv-lite86 v0.2.17
│   │   │   │   │   │   │   └── rand_core v0.6.4
│   │   │   │   │   │   │       └── getrandom v0.2.15 (*)
│   │   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   │   ├── slab v0.4.9
│   │   │   │   │   ├── tokio v1.49.0 (*)
│   │   │   │   │   ├── tokio-util v0.7.18 (*)
│   │   │   │   │   ├── tower-layer v0.3.3
│   │   │   │   │   ├── tower-service v0.3.3
│   │   │   │   │   └── tracing v0.1.40 (*)
│   │   │   │   ├── tower-layer v0.3.3
│   │   │   │   └── tower-service v0.3.3
│   │   │   ├── base64 v0.21.7
│   │   │   ├── bytes v1.11.0 (*)
│   │   │   ├── h2 v0.3.27 (*)
│   │   │   ├── http v0.2.12 (*)
│   │   │   ├── http-body v0.4.6 (*)
│   │   │   ├── hyper v0.14.32 (*)
│   │   │   ├── hyper-timeout v0.4.1
│   │   │   │   ├── hyper v0.14.32 (*)
│   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   ├── tokio v1.49.0 (*)
│   │   │   │   └── tokio-io-timeout v1.2.1
│   │   │   │       ├── pin-project-lite v0.2.14
│   │   │   │       └── tokio v1.49.0 (*)
│   │   │   ├── percent-encoding v2.3.2
│   │   │   ├── pin-project v1.1.10 (*)
│   │   │   ├── prost v0.12.6 (*)
│   │   │   ├── tokio v1.49.0 (*)
│   │   │   ├── tokio-stream v0.1.18 (*)
│   │   │   ├── tower v0.4.13 (*)
│   │   │   ├── tower-layer v0.3.3
│   │   │   ├── tower-service v0.3.3
│   │   │   └── tracing v0.1.40 (*)
│   │   ├── tracing v0.1.40 (*)
│   │   ├── uuid v1.20.0
│   │   │   ├── getrandom v0.3.4
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   └── libc v0.2.180
│   │   │   └── serde_core v1.0.228
│   │   └── zerocopy v0.7.35 (*)
│   ├── parking_lot v0.12.3 (*)
│   ├── serde v1.0.228 (*)
│   ├── serde_json v1.0.149
│   │   ├── itoa v1.0.11
│   │   ├── memchr v2.7.4
│   │   ├── serde_core v1.0.228
│   │   └── zmij v1.0.17
│   ├── thiserror v1.0.63 (*)
│   ├── tokio v1.49.0 (*)
│   ├── tokio-stream v0.1.18 (*)
│   ├── tokio-util v0.7.18 (*)
│   ├── tonic v0.11.0 (*)
│   ├── tonic-web v0.11.0
│   │   ├── base64 v0.21.7
│   │   ├── bytes v1.11.0 (*)
│   │   ├── http v0.2.12 (*)
│   │   ├── http-body v0.4.6 (*)
│   │   ├── hyper v0.14.32 (*)
│   │   ├── pin-project v1.1.10 (*)
│   │   ├── tokio-stream v0.1.18 (*)
│   │   ├── tonic v0.11.0 (*)
│   │   ├── tower-http v0.4.4
│   │   │   ├── bitflags v2.6.0
│   │   │   ├── bytes v1.11.0 (*)
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── http v0.2.12 (*)
│   │   │   ├── http-body v0.4.6 (*)
│   │   │   ├── http-range-header v0.3.1
│   │   │   ├── pin-project-lite v0.2.14
│   │   │   ├── tower v0.4.13 (*)
│   │   │   ├── tower-layer v0.3.3
│   │   │   ├── tower-service v0.3.3
│   │   │   └── tracing v0.1.40 (*)
│   │   ├── tower-layer v0.3.3
│   │   ├── tower-service v0.3.3
│   │   └── tracing v0.1.40 (*)
│   ├── tower v0.4.13 (*)
│   ├── tower-http v0.4.4 (*)
│   ├── tracing v0.1.40 (*)
│   ├── uuid v1.20.0 (*)
│   └── zerocopy v0.7.35 (*)
├── log v0.4.29
└── tokio v1.49.0 (*)
```

### After:

```
grammers-session v0.8.0 (/home/aykut/dev/grammers/grammers-session)
├── futures-core v0.3.31
├── grammers-tl-types v0.8.0 (/home/aykut/dev/grammers/grammers-tl-types)
├── libsql v0.9.29
│   ├── async-trait v0.1.81 (proc-macro)
│   │   ├── proc-macro2 v1.0.93
│   │   │   └── unicode-ident v1.0.12
│   │   ├── quote v1.0.36
│   │   │   └── proc-macro2 v1.0.93 (*)
│   │   └── syn v2.0.98
│   │       ├── proc-macro2 v1.0.93 (*)
│   │       ├── quote v1.0.36 (*)
│   │       └── unicode-ident v1.0.12
│   ├── bitflags v2.6.0
│   ├── bytes v1.11.0
│   │   └── serde v1.0.228
│   │       └── serde_core v1.0.228
│   ├── futures v0.3.31
│   │   ├── futures-channel v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   └── futures-sink v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-executor v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-task v0.3.31
│   │   │   └── futures-util v0.3.31
│   │   │       ├── futures-channel v0.3.31 (*)
│   │   │       ├── futures-core v0.3.31
│   │   │       ├── futures-io v0.3.31
│   │   │       ├── futures-macro v0.3.31 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.93 (*)
│   │   │       │   ├── quote v1.0.36 (*)
│   │   │       │   └── syn v2.0.98 (*)
│   │   │       ├── futures-sink v0.3.31
│   │   │       ├── futures-task v0.3.31
│   │   │       ├── memchr v2.7.4
│   │   │       ├── pin-project-lite v0.2.14
│   │   │       ├── pin-utils v0.1.0
│   │   │       └── slab v0.4.9
│   │   ├── futures-io v0.3.31
│   │   ├── futures-sink v0.3.31
│   │   ├── futures-task v0.3.31
│   │   └── futures-util v0.3.31 (*)
│   ├── libsql-sys v0.9.29
│   │   ├── bytes v1.11.0 (*)
│   │   ├── libsql-ffi v0.9.29
│   │   ├── once_cell v1.21.3
│   │   ├── tracing v0.1.40
│   │   │   ├── pin-project-lite v0.2.14
│   │   │   ├── tracing-attributes v0.1.31 (proc-macro)
│   │   │   │   ├── proc-macro2 v1.0.93 (*)
│   │   │   │   ├── quote v1.0.36 (*)
│   │   │   │   └── syn v2.0.98 (*)
│   │   │   └── tracing-core v0.1.32
│   │   │       └── once_cell v1.21.3
│   │   └── zerocopy v0.7.35
│   │       ├── byteorder v1.5.0
│   │       └── zerocopy-derive v0.7.35 (proc-macro)
│   │           ├── proc-macro2 v1.0.93 (*)
│   │           ├── quote v1.0.36 (*)
│   │           └── syn v2.0.98 (*)
│   ├── parking_lot v0.12.3
│   │   ├── lock_api v0.4.12
│   │   │   └── scopeguard v1.2.0
│   │   └── parking_lot_core v0.9.10
│   │       ├── cfg-if v1.0.0
│   │       ├── libc v0.2.180
│   │       └── smallvec v1.13.2
│   ├── thiserror v1.0.63
│   │   └── thiserror-impl v1.0.63 (proc-macro)
│   │       ├── proc-macro2 v1.0.93 (*)
│   │       ├── quote v1.0.36 (*)
│   │       └── syn v2.0.98 (*)
│   └── tracing v0.1.40 (*)
├── log v0.4.29
└── tokio v1.49.0
    └── pin-project-lite v0.2.14
```
</details>