### PR TITLE
IPv6 Support

### DIFF
--- a/grammers-mtsender/src/configuration.rs
+++ b/grammers-mtsender/src/configuration.rs
@@ -38,6 +38,7 @@ pub struct ConnectionParams {
     /// the host manually and selecting an IP address of your choice.
     #[cfg(feature = "proxy")]
     pub proxy_url: Option<String>,
+    pub use_ipv6: bool,
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -67,6 +68,7 @@ impl Default for ConnectionParams {
             app_version: env!("CARGO_PKG_VERSION").to_string(),
             system_lang_code,
             lang_code,
+            use_ipv6: false,
             #[cfg(feature = "proxy")]
             proxy_url: None,
             __non_exhaustive: (),

--- a/grammers-mtsender/src/configuration.rs
+++ b/grammers-mtsender/src/configuration.rs
@@ -38,6 +38,7 @@ pub struct ConnectionParams {
     /// the host manually and selecting an IP address of your choice.
     #[cfg(feature = "proxy")]
     pub proxy_url: Option<String>,
+    /// Whether to connect via IPv6 instead of defaulting to IPv4.
     pub use_ipv6: bool,
     #[doc(hidden)]
     pub __non_exhaustive: (),

--- a/grammers-mtsender/src/sender_pool.rs
+++ b/grammers-mtsender/src/sender_pool.rs
@@ -292,7 +292,6 @@ impl SenderPoolRunner {
         let transport = transport::Full::new;
 
         let address = if self.connection_params.use_ipv6 {
-            log::info!("Using IPv6 connection");
             dc_option.ipv6.into()
         } else {
             dc_option.ipv4.into()

--- a/grammers-mtsender/src/sender_pool.rs
+++ b/grammers-mtsender/src/sender_pool.rs
@@ -161,12 +161,6 @@ impl SenderPool {
         Self::with_configuration(session, api_id, Default::default())
     }
 
-    // Enable IPv6 for connections created by this sender pool.
-    pub fn use_ipv6(mut self) -> Self {
-        self.runner.connection_params.use_ipv6 = true;
-        self
-    }
-
     /// Creates a new sender pool with non-[`ConnectionParams::default`] configuration.
     pub fn with_configuration<S: Session + 'static>(
         session: Arc<S>,

--- a/grammers-session/src/dc_options.rs
+++ b/grammers-session/src/dc_options.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::net::{Ipv4Addr, SocketAddrV4, SocketAddrV6};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 use crate::types::DcOption;
 
@@ -16,8 +16,8 @@ const fn ipv4(a: u8, b: u8, c: u8, d: u8) -> SocketAddrV4 {
     SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), 443)
 }
 
-const fn ipv6(a: u8, b: u8, c: u8, d: u8) -> SocketAddrV6 {
-    SocketAddrV6::new(ipv4(a, b, c, d).ip().to_ipv6_compatible(), 443, 0, 0)
+const fn ipv6(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> SocketAddrV6 {
+    SocketAddrV6::new(Ipv6Addr::new(a, b, c, d, e, f, g, h), 443, 0, 0)
 }
 
 /// Hardcoded known `static` options from `functions::help::GetConfig`.
@@ -25,31 +25,31 @@ pub(crate) const KNOWN_DC_OPTIONS: [DcOption; 5] = [
     DcOption {
         id: 1,
         ipv4: ipv4(149, 154, 175, 53),
-        ipv6: ipv6(149, 154, 175, 53),
+        ipv6: ipv6(0x2001, 0xb28, 0xf23d, 0xf001, 0, 0, 0, 0xa),
         auth_key: None,
     },
     DcOption {
         id: 2,
         ipv4: ipv4(149, 154, 167, 41),
-        ipv6: ipv6(149, 154, 167, 41),
+        ipv6: ipv6(0x2001, 0x67c, 0x4e8, 0xf002, 0, 0, 0, 0xa),
         auth_key: None,
     },
     DcOption {
         id: 3,
         ipv4: ipv4(149, 154, 175, 100),
-        ipv6: ipv6(149, 154, 175, 100),
+        ipv6: ipv6(0x2001, 0xb28, 0xf23d, 0xf003, 0, 0, 0, 0xa),
         auth_key: None,
     },
     DcOption {
         id: 4,
         ipv4: ipv4(149, 154, 167, 92),
-        ipv6: ipv6(149, 154, 167, 92),
+        ipv6: ipv6(0x2001, 0x67c, 0x4e8, 0xf004, 0, 0, 0, 0xa),
         auth_key: None,
     },
     DcOption {
         id: 5,
         ipv4: ipv4(91, 108, 56, 104),
-        ipv6: ipv6(91, 108, 56, 104),
+        ipv6: ipv6(0x2001, 0xb28, 0xf23f, 0xf005, 0, 0, 0, 0xa),
         auth_key: None,
     },
 ];


### PR DESCRIPTION
We may need a more graceful implement, such as a fallback or something else.  
I would like some guidance on what the behavior it should look like.

Currently, setting the `PREFER_V6` env var simply forces IPv6 connections.
