### PR TITLE
Add requires_join_request methods to Channel and Group

### DIFF
--- a/grammers-client/src/peer/channel.rs
+++ b/grammers-client/src/peer/channel.rs
@@ -214,6 +214,11 @@ impl Channel {
             None => None,
         }
     }
+
+    /// Return whether this channel requires join requests.
+    pub fn requires_join_request(&self) -> bool {
+        self.raw.join_request
+    }
 }
 
 impl TryFrom<Channel> for ChannelKind {

--- a/grammers-client/src/peer/group.rs
+++ b/grammers-client/src/peer/group.rs
@@ -201,6 +201,18 @@ impl Group {
             C::Channel(_) | C::ChannelForbidden(_) => true,
         }
     }
+
+    /// Return whether this group requires join requests.
+    pub fn requires_join_request(&self) -> bool {
+        use tl::enums::Chat;
+
+        match &self.raw {
+            Chat::Empty(_) | Chat::Chat(_) | Chat::Forbidden(_) | Chat::ChannelForbidden(_) => {
+                false
+            }
+            Chat::Channel(channel) => channel.join_request,
+        }
+    }
 }
 
 impl From<Group> for PeerInfo {


### PR DESCRIPTION
- Add `requires_join_request()` method to `Channel` that returns `self.raw.join_request`
- Add `requires_join_request()` method to `Group` that checks the underlying `Chat` enum variant