### PR TITLE
Add SOCKS4 and HTTP CONNECT proxy support

### DIFF
--- a/grammers-mtsender/Cargo.toml
+++ b/grammers-mtsender/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "network-programming"]
 edition = "2024"
 
 [features]
-proxy = ["tokio-socks", "hickory-resolver", "url"]
+proxy = ["tokio-socks", "hickory-resolver", "url", "async-http-proxy"]
 
 [dependencies]
 bytes = "1.10.1"
@@ -29,6 +29,7 @@ tokio = { version = "1.47.1", default-features = false, features = ["io-util", "
 tokio-socks = { version = "0.5.2", optional = true }
 hickory-resolver = { version = "0.25.2", optional = true }
 url = { version = "2.5.7", optional = true }
+async-http-proxy = { version = "1.2.5", features = ["runtime-tokio", "basic-auth"], optional = true }
 
 [dev-dependencies]
 simple_logger = { version = "5.0.0", default-features = false, features = ["colors"] }

--- a/grammers-mtsender/DEPS.md
+++ b/grammers-mtsender/DEPS.md
@@ -63,7 +63,11 @@ Used to look up the IP address of the proxy host if a domain is provided.
 
 ## tokio-socks
 
-SOCKS5 proxy support.
+SOCKS4 and SOCKS5 proxy support.
+
+## async-http-proxy
+
+HTTP CONNECT proxy support.
 
 ## socks5-server
 


### PR DESCRIPTION
- Add SOCKS4 proxy support via `tokio-socks` (already a dependency)
- Add HTTP CONNECT proxy support via `async-http-proxy`
- No manual protocol implementations, all handled by established crates